### PR TITLE
Add OpenAPI request body docs

### DIFF
--- a/ihp/IHP/OpenApiSupport.hs
+++ b/ihp/IHP/OpenApiSupport.hs
@@ -6,53 +6,53 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
-module IHP.OpenApiSupport
-    ( ToSchema (..)
-    , NamedSchema (..)
-    , Schema
-    , toSchema
-    , genericDeclareNamedSchema
-    , defaultSchemaOptions
-    , OpenApiGenerationException (..)
-    , OpenApiInfo (..)
-    , defaultOpenApiInfo
-    , buildOpenApi
-    , buildOpenApiWithInfo
-    , SwaggerUiOptions (..)
-    , defaultSwaggerUiOptions
-    , swaggerUi
-    , swaggerUiWithOptions
-    ) where
+module IHP.OpenApiSupport (
+    ToSchema (..),
+    NamedSchema (..),
+    Schema,
+    toSchema,
+    genericDeclareNamedSchema,
+    defaultSchemaOptions,
+    OpenApiGenerationException (..),
+    OpenApiInfo (..),
+    defaultOpenApiInfo,
+    buildOpenApi,
+    buildOpenApiWithInfo,
+    SwaggerUiOptions (..),
+    defaultSwaggerUiOptions,
+    swaggerUi,
+    swaggerUiWithOptions,
+) where
 
-import IHP.Prelude
-import IHP.RouterSupport
-import IHP.Router.Types (UnexpectedMethodException (..))
-import IHP.ViewSupport (JsonResponse)
-import IHP.ModelSupport
+import Control.Exception qualified as Exception
+import Control.Monad.State.Strict qualified as State
+import Data.Aeson qualified as JSON
+import Data.Aeson.Key qualified as JSON.Key
+import Data.Aeson.KeyMap qualified as JSON.KeyMap
 import Data.Attoparsec.ByteString.Char8 (string)
-import Data.OpenApi (ToSchema (..), NamedSchema (..), Schema, Definitions, Referenced, declareNamedSchema, declareSchemaRef, toSchema, genericDeclareNamedSchema, defaultSchemaOptions)
-import Data.OpenApi.Declare (runDeclare)
-import qualified Data.Aeson as JSON
-import qualified Data.Aeson.Key as JSON.Key
-import qualified Data.Aeson.KeyMap as JSON.KeyMap
-import qualified Data.ByteString.Char8 as ByteString
-import qualified Data.ByteString.Lazy as LazyByteString
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Typeable as Typeable
-import qualified Control.Exception as Exception
-import qualified Control.Monad.State.Strict as State
-import qualified Text.Blaze.Html.Renderer.Utf8 as Blaze
-import qualified Text.Blaze.Html5 as Html5
-import qualified Text.Blaze.Html5.Attributes as Attr
+import Data.ByteString.Char8 qualified as ByteString
+import Data.ByteString.Lazy qualified as LazyByteString
 import Data.Data
+import Data.Map.Strict qualified as Map
+import Data.OpenApi (Definitions, NamedSchema (..), Referenced, Schema, ToSchema (..), declareNamedSchema, declareSchemaRef, defaultSchemaOptions, genericDeclareNamedSchema, toSchema)
+import Data.OpenApi.Declare (runDeclare)
 import Data.Semigroup (Semigroup (..))
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Typeable qualified as Typeable
 import Data.UUID (nil)
+import IHP.ModelSupport
+import IHP.Prelude
+import IHP.Router.Types (UnexpectedMethodException (..))
+import IHP.RouterSupport
+import IHP.ViewSupport (JsonResponse)
 import Network.HTTP.Types.Header (hContentType)
 import Network.HTTP.Types.Method (StdMethod (..), parseMethod)
 import Network.HTTP.Types.Status (status200)
 import Network.Wai (Request, Response, defaultRequest, requestMethod, responseBuilder, responseLBS)
+import Text.Blaze.Html.Renderer.Utf8 qualified as Blaze
+import Text.Blaze.Html5 qualified as Html5
+import Text.Blaze.Html5.Attributes qualified as Attr
 
 data OpenApiInfo = OpenApiInfo
     { openApiTitle :: Text
@@ -72,23 +72,26 @@ data OpenApiDocument = OpenApiDocument
     }
 
 instance Semigroup OpenApiDocument where
-    left <> right = OpenApiDocument
-        { pathOperations = Map.unionWith Map.union left.pathOperations right.pathOperations
-        , componentSchemas = left.componentSchemas <> right.componentSchemas
-        }
+    left <> right =
+        OpenApiDocument
+            { pathOperations = Map.unionWith Map.union left.pathOperations right.pathOperations
+            , componentSchemas = left.componentSchemas <> right.componentSchemas
+            }
 
 instance Monoid OpenApiDocument where
-    mempty = OpenApiDocument
-        { pathOperations = mempty
-        , componentSchemas = mempty
-        }
+    mempty =
+        OpenApiDocument
+            { pathOperations = mempty
+            , componentSchemas = mempty
+            }
 
-defaultOpenApiInfo :: forall application. Typeable.Typeable application => OpenApiInfo
-defaultOpenApiInfo = OpenApiInfo
-    { openApiTitle = cs (show (Typeable.typeRep (Proxy @application))) <> " API"
-    , openApiVersion = "1.0.0"
-    , openApiDescription = Nothing
-    }
+defaultOpenApiInfo :: forall application. (Typeable.Typeable application) => OpenApiInfo
+defaultOpenApiInfo =
+    OpenApiInfo
+        { openApiTitle = cs (show (Typeable.typeRep (Proxy @application))) <> " API"
+        , openApiVersion = "1.0.0"
+        , openApiDescription = Nothing
+        }
 
 data SwaggerUiOptions = SwaggerUiOptions
     { swaggerUiPath :: ByteString
@@ -101,88 +104,91 @@ data SwaggerUiOptions = SwaggerUiOptions
     }
     deriving (Eq, Show)
 
--- | Default Swagger UI settings for an application.
---
--- This serves the generated OpenAPI JSON at @/api-docs/openapi.json@ and the
--- Swagger UI at @/api-docs@.
-defaultSwaggerUiOptions :: forall application. Typeable.Typeable application => SwaggerUiOptions
+{- | Default Swagger UI settings for an application.
+
+This serves the generated OpenAPI JSON at @/api-docs/openapi.json@ and the
+Swagger UI at @/api-docs@.
+-}
+defaultSwaggerUiOptions :: forall application. (Typeable.Typeable application) => SwaggerUiOptions
 defaultSwaggerUiOptions =
     let info = defaultOpenApiInfo @application
-    in SwaggerUiOptions
-        { swaggerUiPath = "/api-docs"
-        , swaggerUiOpenApiPath = "/openapi.json"
-        , swaggerUiInfo = info
-        , swaggerUiTitle = Nothing
-        , swaggerUiCssUrl = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
-        , swaggerUiBundleJsUrl = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"
-        , swaggerUiStandalonePresetJsUrl = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"
-        }
+     in SwaggerUiOptions
+            { swaggerUiPath = "/api-docs"
+            , swaggerUiOpenApiPath = "/openapi.json"
+            , swaggerUiInfo = info
+            , swaggerUiTitle = Nothing
+            , swaggerUiCssUrl = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css"
+            , swaggerUiBundleJsUrl = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"
+            , swaggerUiStandalonePresetJsUrl = "https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"
+            }
 
 buildOpenApi :: forall application. (FrontController application, Typeable.Typeable application) => application -> JSON.Value
 buildOpenApi = buildOpenApiWithInfo (defaultOpenApiInfo @application)
 
-buildOpenApiWithInfo :: forall application. FrontController application => OpenApiInfo -> application -> JSON.Value
+buildOpenApiWithInfo :: forall application. (FrontController application) => OpenApiInfo -> application -> JSON.Value
 buildOpenApiWithInfo info application =
     let ?request = defaultRequest
         ?respond = dummyRespond
         ?application = application
-    in
-        let routeTree = RouteCollection (controllers @application |> map routeInspection)
-        in case collectPaths "" routeTree of
-            Left errorMessage -> throwOpenApiGenerationException errorMessage
-            Right OpenApiDocument { pathOperations, componentSchemas } ->
-                JSON.object
-                    ( [ Just ("openapi" JSON..= ("3.0.3" :: Text))
-                      , Just ("info" JSON..= openApiInfoValue info)
-                      , Just ("paths" JSON..= openApiPathsValue pathOperations)
-                      , if componentSchemas == mempty then Nothing else Just ("components" JSON..= openApiComponentsValue componentSchemas)
-                      ]
-                        |> catMaybes
-                    )
-    where
-        dummyRespond _ = error "buildOpenApi: response callback should never be called"
+     in let routeTree = RouteCollection (controllers @application |> map routeInspection)
+         in case collectPaths "" routeTree of
+                Left errorMessage -> throwOpenApiGenerationException errorMessage
+                Right OpenApiDocument{pathOperations, componentSchemas} ->
+                    JSON.object
+                        ( [ Just ("openapi" JSON..= ("3.0.3" :: Text))
+                          , Just ("info" JSON..= openApiInfoValue info)
+                          , Just ("paths" JSON..= openApiPathsValue pathOperations)
+                          , if componentSchemas == mempty then Nothing else Just ("components" JSON..= openApiComponentsValue componentSchemas)
+                          ]
+                            |> catMaybes
+                        )
+  where
+    dummyRespond _ = error "buildOpenApi: response callback should never be called"
 
 throwOpenApiGenerationException :: Text -> a
 throwOpenApiGenerationException = Exception.throw . OpenApiGenerationException
 {-# INLINE throwOpenApiGenerationException #-}
 
--- | Mounts Swagger UI for the current front controller using 'defaultSwaggerUiOptions'.
---
--- This adds two undocumented routes:
---
--- - the Swagger UI HTML at @/api-docs@
--- - the generated OpenAPI document at @/api-docs/openapi.json@
-swaggerUi
-    :: forall application.
-        ( FrontController application
-        , Typeable.Typeable application
-        , ?application :: application
-        )
-    => ControllerRoute application
+{- | Mounts Swagger UI for the current front controller using 'defaultSwaggerUiOptions'.
+
+This adds two undocumented routes:
+
+- the Swagger UI HTML at @/api-docs@
+- the generated OpenAPI document at @/api-docs/openapi.json@
+-}
+swaggerUi ::
+    forall application.
+    ( FrontController application
+    , Typeable.Typeable application
+    , ?application :: application
+    ) =>
+    ControllerRoute application
 swaggerUi = swaggerUiWithOptions (defaultSwaggerUiOptions @application)
 
--- | Mounts Swagger UI and the generated OpenAPI JSON for the current front controller.
---
--- The JSON endpoint is derived from the same mounted router tree via
--- 'buildOpenApiWithInfo', so the documentation stays aligned with the
--- application routing.
-swaggerUiWithOptions
-    :: forall application.
-        ( FrontController application
-        , ?application :: application
-        )
-    => SwaggerUiOptions
-    -> ControllerRoute application
-swaggerUiWithOptions options@SwaggerUiOptions { swaggerUiPath, swaggerUiOpenApiPath, swaggerUiInfo } =
+{- | Mounts Swagger UI and the generated OpenAPI JSON for the current front controller.
+
+The JSON endpoint is derived from the same mounted router tree via
+'buildOpenApiWithInfo', so the documentation stays aligned with the
+application routing.
+-}
+swaggerUiWithOptions ::
+    forall application.
+    ( FrontController application
+    , ?application :: application
+    ) =>
+    SwaggerUiOptions ->
+    ControllerRoute application
+swaggerUiWithOptions options@SwaggerUiOptions{swaggerUiPath, swaggerUiOpenApiPath, swaggerUiInfo} =
     let normalizedBasePath = normalizeSwaggerUiBasePath swaggerUiPath
         normalizedOpenApiPath = normalizeSwaggerUiChildPath swaggerUiOpenApiPath
-        htmlResponse = responseBuilder status200 [(hContentType, "text/html; charset=utf-8")] (Blaze.renderHtmlBuilder (swaggerUiHtml options { swaggerUiPath = normalizedBasePath, swaggerUiOpenApiPath = normalizedOpenApiPath }))
+        htmlResponse = responseBuilder status200 [(hContentType, "text/html; charset=utf-8")] (Blaze.renderHtmlBuilder (swaggerUiHtml options{swaggerUiPath = normalizedBasePath, swaggerUiOpenApiPath = normalizedOpenApiPath}))
         application = ?application
-    in withPrefix normalizedBasePath
-        [ getResponseRoute normalizedOpenApiPath (\_ -> responseLBS status200 [(hContentType, "application/json")] (JSON.encode (buildOpenApiWithInfo swaggerUiInfo application)))
-        , getResponseRoute "" (\_ -> htmlResponse)
-        , getResponseRoute "/" (\_ -> htmlResponse)
-        ]
+     in withPrefix
+            normalizedBasePath
+            [ getResponseRoute normalizedOpenApiPath (\_ -> responseLBS status200 [(hContentType, "application/json")] (JSON.encode (buildOpenApiWithInfo swaggerUiInfo application)))
+            , getResponseRoute "" (\_ -> htmlResponse)
+            , getResponseRoute "/" (\_ -> htmlResponse)
+            ]
 
 getResponseRoute :: ByteString -> (Request -> Response) -> ControllerRoute application
 getResponseRoute path toResponse = rawRoute do
@@ -194,7 +200,7 @@ handleGet request respond response =
     case parseMethod (requestMethod request) of
         Right GET -> respond response
         Right HEAD -> respond response
-        Right method -> Exception.throw UnexpectedMethodException { allowedMethods = [GET, HEAD], method }
+        Right method -> Exception.throw UnexpectedMethodException{allowedMethods = [GET, HEAD], method}
         Left err -> Exception.throwIO (OpenApiGenerationException ("Invalid HTTP method: " <> cs err))
 
 normalizeSwaggerUiBasePath :: ByteString -> ByteString
@@ -211,21 +217,21 @@ normalizeSwaggerUiChildPath path
     | otherwise = path
 
 swaggerUiHtml :: SwaggerUiOptions -> Html5.Html
-swaggerUiHtml SwaggerUiOptions { swaggerUiOpenApiPath, swaggerUiInfo, swaggerUiTitle, swaggerUiCssUrl, swaggerUiBundleJsUrl, swaggerUiStandalonePresetJsUrl } =
+swaggerUiHtml SwaggerUiOptions{swaggerUiOpenApiPath, swaggerUiInfo, swaggerUiTitle, swaggerUiCssUrl, swaggerUiBundleJsUrl, swaggerUiStandalonePresetJsUrl} =
     let title = fromMaybe (swaggerUiInfo.openApiTitle <> " Swagger UI") swaggerUiTitle
         openApiUrlLiteral = jsonStringLiteral (relativeSwaggerUiOpenApiUrl swaggerUiOpenApiPath)
-    in Html5.docTypeHtml do
-        Html5.head do
-            Html5.meta Html5.! Attr.charset "utf-8"
-            Html5.meta Html5.! Attr.name "viewport" Html5.! Attr.content "width=device-width, initial-scale=1"
-            Html5.title (Html5.toHtml title)
-            Html5.link Html5.! Attr.rel "stylesheet" Html5.! Attr.href (Html5.textValue swaggerUiCssUrl)
-            Html5.style "html { box-sizing: border-box; overflow-y: scroll; } *, *:before, *:after { box-sizing: inherit; } body { margin: 0; background: #fafafa; }"
-        Html5.body do
-            Html5.div mempty Html5.! Attr.id "swagger-ui"
-            Html5.script mempty Html5.! Attr.src (Html5.textValue swaggerUiBundleJsUrl)
-            Html5.script mempty Html5.! Attr.src (Html5.textValue swaggerUiStandalonePresetJsUrl)
-            Html5.script (Html5.preEscapedToHtml (swaggerUiBootScript openApiUrlLiteral))
+     in Html5.docTypeHtml do
+            Html5.head do
+                Html5.meta Html5.! Attr.charset "utf-8"
+                Html5.meta Html5.! Attr.name "viewport" Html5.! Attr.content "width=device-width, initial-scale=1"
+                Html5.title (Html5.toHtml title)
+                Html5.link Html5.! Attr.rel "stylesheet" Html5.! Attr.href (Html5.textValue swaggerUiCssUrl)
+                Html5.style "html { box-sizing: border-box; overflow-y: scroll; } *, *:before, *:after { box-sizing: inherit; } body { margin: 0; background: #fafafa; }"
+            Html5.body do
+                Html5.div mempty Html5.! Attr.id "swagger-ui"
+                Html5.script mempty Html5.! Attr.src (Html5.textValue swaggerUiBundleJsUrl)
+                Html5.script mempty Html5.! Attr.src (Html5.textValue swaggerUiStandalonePresetJsUrl)
+                Html5.script (Html5.preEscapedToHtml (swaggerUiBootScript openApiUrlLiteral))
 
 relativeSwaggerUiOpenApiUrl :: ByteString -> Text
 relativeSwaggerUiOpenApiUrl openApiPath =
@@ -248,13 +254,14 @@ swaggerUiBootScript openApiUrlLiteral =
 jsonStringLiteral :: Text -> Text
 jsonStringLiteral = cs . LazyByteString.toStrict . JSON.encode
 openApiInfoValue :: OpenApiInfo -> JSON.Value
-openApiInfoValue OpenApiInfo { openApiTitle, openApiVersion, openApiDescription } = JSON.object
-    ( [ Just ("title" JSON..= openApiTitle)
-      , Just ("version" JSON..= openApiVersion)
-      , ("description" JSON..=) <$> openApiDescription
-      ]
-        |> catMaybes
-    )
+openApiInfoValue OpenApiInfo{openApiTitle, openApiVersion, openApiDescription} =
+    JSON.object
+        ( [ Just ("title" JSON..= openApiTitle)
+          , Just ("version" JSON..= openApiVersion)
+          , ("description" JSON..=) <$> openApiDescription
+          ]
+            |> catMaybes
+        )
 
 type PathOperations = Map.Map Text (Map.Map Text JSON.Value)
 
@@ -265,40 +272,41 @@ collectPaths currentPrefix = \case
     RouteCollection routes -> mconcat <$> mapM (collectPaths currentPrefix) routes
     RoutePrefix routePrefix routes ->
         let prefixedPath = appendPathPrefix currentPrefix (Text.decodeUtf8 routePrefix)
-        in mconcat <$> mapM (collectPaths prefixedPath) routes
+         in mconcat <$> mapM (collectPaths prefixedPath) routes
 
 collectDocumentedRoute :: Text -> DocumentedRouteInfo -> Either Text OpenApiDocument
-collectDocumentedRoute _ (AutoRouteControllerInfo { documentedActions = Nothing }) = Right mempty
-collectDocumentedRoute currentPrefix (AutoRouteControllerInfo { documentedActions = Just docs }) =
+collectDocumentedRoute _ (AutoRouteControllerInfo{documentedActions = Nothing}) = Right mempty
+collectDocumentedRoute currentPrefix (AutoRouteControllerInfo{documentedActions = Just docs}) =
     foldl' (insertActionOperation currentPrefix) (Right mempty) docs
 
-insertActionOperation
-    :: forall controller.
-        ( AutoRoute controller
-        , Data controller
-        , Typeable.Typeable controller
-        )
-    => Text
-    -> Either Text OpenApiDocument
-    -> ActionDoc controller
-    -> Either Text OpenApiDocument
-insertActionOperation currentPrefix pathState doc@ActionDoc { actionDocName } = do
-    OpenApiDocument { pathOperations, componentSchemas } <- pathState
+insertActionOperation ::
+    forall controller.
+    ( AutoRoute controller
+    , Data controller
+    , Typeable.Typeable controller
+    ) =>
+    Text ->
+    Either Text OpenApiDocument ->
+    ActionDoc controller ->
+    Either Text OpenApiDocument
+insertActionOperation currentPrefix pathState doc@ActionDoc{actionDocName} = do
+    OpenApiDocument{pathOperations, componentSchemas} <- pathState
     constructor <- findControllerConstructor @controller actionDocName
     hasCustomPath <- actionUsesCustomPath @controller constructor
     if hasCustomPath
-        then pure OpenApiDocument { pathOperations, componentSchemas }
+        then pure OpenApiDocument{pathOperations, componentSchemas}
         else do
             let actionPath = appendPathPrefix currentPrefix (actionPrefixText @controller <> stripActionSuffixText actionDocName)
             parameters <- deriveActionParameters @controller constructor
             let (operation, operationSchemas) = actionDocOperationValue doc parameters
             let methods = allowedMethodsForAction @controller (Text.encodeUtf8 actionDocName)
-            pure OpenApiDocument
-                { pathOperations = foldl' (insertMethod actionPath operation) pathOperations methods
-                , componentSchemas = componentSchemas <> operationSchemas
-                }
+            pure
+                OpenApiDocument
+                    { pathOperations = foldl' (insertMethod actionPath operation) pathOperations methods
+                    , componentSchemas = componentSchemas <> operationSchemas
+                    }
 
-findControllerConstructor :: forall controller. Data controller => Text -> Either Text Constr
+findControllerConstructor :: forall controller. (Data controller) => Text -> Either Text Constr
 findControllerConstructor actionName =
     dataTypeConstrs (dataTypeOf (undefined :: controller))
         |> find (\constructor -> cs (showConstr constructor) == actionName)
@@ -308,10 +316,10 @@ findControllerConstructor actionName =
 
 insertMethod :: Text -> JSON.Value -> PathOperations -> StdMethod -> PathOperations
 insertMethod actionPath operation paths method = Map.alter updatePath actionPath paths
-    where
-        methodName = httpMethodName method
-        updatePath Nothing = Just (Map.singleton methodName operation)
-        updatePath (Just operations) = Just (Map.insert methodName operation operations)
+  where
+    methodName = httpMethodName method
+    updatePath Nothing = Just (Map.singleton methodName operation)
+    updatePath (Just operations) = Just (Map.insert methodName operation operations)
 
 httpMethodName :: StdMethod -> Text
 httpMethodName = \case
@@ -336,16 +344,17 @@ appendPathPrefix currentPrefix nextPrefix =
             | otherwise = text
         normalizedCurrent = currentPrefix |> normalize |> trimTrailingSlash
         normalizedNext = normalize nextPrefix
-    in case (normalizedCurrent, normalizedNext) of
-        ("", next) -> next
-        (current, "/") -> current <> "/"
-        (current, next) -> current <> next
+     in case (normalizedCurrent, normalizedNext) of
+            ("", next) -> next
+            (current, "/") -> current <> "/"
+            (current, next) -> current <> next
 
 openApiPathsValue :: PathOperations -> JSON.Value
 openApiPathsValue paths =
     paths
         |> Map.toList
-        |> map (\(path, operations) ->
+        |> map
+            ( \(path, operations) ->
                 ( JSON.Key.fromText path
                 , operations
                     |> Map.toList
@@ -358,18 +367,30 @@ openApiPathsValue paths =
         |> JSON.Object
 
 openApiComponentsValue :: Definitions Schema -> JSON.Value
-openApiComponentsValue schemas = JSON.object
-    [ "schemas" JSON..= schemas
-    ]
+openApiComponentsValue schemas =
+    JSON.object
+        [ "schemas" JSON..= schemas
+        ]
 
 actionDocOperationValue :: forall controller. ActionDoc controller -> [QueryParameterDocumentation] -> (JSON.Value, Definitions Schema)
-actionDocOperationValue ActionDoc { actionDocName, actionDocSummary, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView } parameters =
-    let SchemaDocumentation { documentedSchema, documentedDefinitions } = responseSchemaValue actionDocView
-        parameterDefinitions = parameters |> map (\QueryParameterDocumentation { parameterDefinitions } -> parameterDefinitions) |> mconcat
-    in
-        ( JSON.object
+actionDocOperationValue ActionDoc{actionDocName, actionDocSummary, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView, actionDocRequestBody} parameters =
+    let SchemaDocumentation{documentedSchema, documentedDefinitions} = responseSchemaValue actionDocView
+        parameterDefinitions = parameters |> map (\QueryParameterDocumentation{parameterDefinitions} -> parameterDefinitions) |> mconcat
+        requestBodyDocumentation =
+            actionDocRequestBody
+                |> fmap openApiRequestBodySchemaValue
+        requestBodyDefinitions =
+            requestBodyDocumentation
+                |> fmap (.documentedDefinitions)
+                |> fromMaybe mempty
+        requestBodyValue =
+            case (actionDocRequestBody, requestBodyDocumentation) of
+                (Just requestBodyDoc, Just schemaDocumentation) -> Just ("requestBody" JSON..= openApiRequestBodyValue requestBodyDoc schemaDocumentation.documentedSchema)
+                _ -> Nothing
+     in ( JSON.object
             ( [ Just ("parameters" JSON..= map queryParameterValue parameters)
               , Just ("responses" JSON..= JSON.object ["200" JSON..= successResponseValue documentedSchema])
+              , requestBodyValue
               , ("summary" JSON..=) <$> actionDocSummary
               , ("description" JSON..=) <$> actionDocDescription
               , if null actionDocTags then Nothing else Just ("tags" JSON..= actionDocTags)
@@ -378,21 +399,41 @@ actionDocOperationValue ActionDoc { actionDocName, actionDocSummary, actionDocDe
               ]
                 |> catMaybes
             )
-        , documentedDefinitions <> parameterDefinitions
+        , documentedDefinitions <> parameterDefinitions <> requestBodyDefinitions
         )
 
-responseSchemaValue :: forall view. ToSchema (JsonResponse view) => Proxy view -> SchemaDocumentation
+openApiRequestBodySchemaValue :: OpenApiRequestBodyDoc -> SchemaDocumentation
+openApiRequestBodySchemaValue OpenApiRequestBodyDoc{requestBodySchema} =
+    declareSchemaDocumentation requestBodySchema
+
+openApiRequestBodyValue :: OpenApiRequestBodyDoc -> Referenced Schema -> JSON.Value
+openApiRequestBodyValue OpenApiRequestBodyDoc{requestBodyRequired} schema =
+    JSON.object
+        [ "required" JSON..= requestBodyRequired
+        , "content"
+            JSON..= JSON.object
+                [ "application/json"
+                    JSON..= JSON.object
+                        [ "schema" JSON..= schema
+                        ]
+                ]
+        ]
+
+responseSchemaValue :: forall view. (ToSchema (JsonResponse view)) => Proxy view -> SchemaDocumentation
 responseSchemaValue _ = declareSchemaDocumentation (Proxy @(JsonResponse view))
 
 successResponseValue :: Referenced Schema -> JSON.Value
-successResponseValue schema = JSON.object
-    [ "description" JSON..= ("Successful response" :: Text)
-    , "content" JSON..= JSON.object
-        [ "application/json" JSON..= JSON.object
-            [ "schema" JSON..= schema
-            ]
+successResponseValue schema =
+    JSON.object
+        [ "description" JSON..= ("Successful response" :: Text)
+        , "content"
+            JSON..= JSON.object
+                [ "application/json"
+                    JSON..= JSON.object
+                        [ "schema" JSON..= schema
+                        ]
+                ]
         ]
-    ]
 
 data QueryParameterDocumentation = QueryParameterDocumentation
     { parameterName :: Text
@@ -403,36 +444,37 @@ data QueryParameterDocumentation = QueryParameterDocumentation
     }
 
 queryParameterValue :: QueryParameterDocumentation -> JSON.Value
-queryParameterValue QueryParameterDocumentation { parameterName, parameterRequired, parameterSchema, parameterExplode } = JSON.object
-    ( [ Just ("name" JSON..= parameterName)
-      , Just ("in" JSON..= ("query" :: Text))
-      , Just ("required" JSON..= parameterRequired)
-      , Just ("schema" JSON..= parameterSchema)
-      , if isJust parameterExplode then Just ("style" JSON..= ("form" :: Text)) else Nothing
-      , ("explode" JSON..=) <$> parameterExplode
-      ]
-        |> catMaybes
-    )
+queryParameterValue QueryParameterDocumentation{parameterName, parameterRequired, parameterSchema, parameterExplode} =
+    JSON.object
+        ( [ Just ("name" JSON..= parameterName)
+          , Just ("in" JSON..= ("query" :: Text))
+          , Just ("required" JSON..= parameterRequired)
+          , Just ("schema" JSON..= parameterSchema)
+          , if isJust parameterExplode then Just ("style" JSON..= ("form" :: Text)) else Nothing
+          , ("explode" JSON..=) <$> parameterExplode
+          ]
+            |> catMaybes
+        )
 
 data SchemaDocumentation = SchemaDocumentation
     { documentedSchema :: Referenced Schema
     , documentedDefinitions :: Definitions Schema
     }
 
-declareSchemaDocumentation :: forall schema. ToSchema schema => Proxy schema -> SchemaDocumentation
+declareSchemaDocumentation :: forall schema. (ToSchema schema) => Proxy schema -> SchemaDocumentation
 declareSchemaDocumentation proxy =
     let (definitions, schema) = runDeclare (declareSchemaRef proxy) mempty
-    in SchemaDocumentation
-        { documentedSchema = schema
-        , documentedDefinitions = definitions
-        }
+     in SchemaDocumentation
+            { documentedSchema = schema
+            , documentedDefinitions = definitions
+            }
 
-queryParameterDocumentation :: forall field. Data field => Text -> Maybe QueryParameterDocumentation
+queryParameterDocumentation :: forall field. (Data field) => Text -> Maybe QueryParameterDocumentation
 queryParameterDocumentation parameterName =
     directParameterDocumentation @field parameterName
         <|> wrappedIdParameterDocumentation @field parameterName
 
-directParameterDocumentation :: forall field. Data field => Text -> Maybe QueryParameterDocumentation
+directParameterDocumentation :: forall field. (Data field) => Text -> Maybe QueryParameterDocumentation
 directParameterDocumentation parameterName =
     asum
         [ eqT @field @Text |> fmap (\Refl -> requiredParameter @Text parameterName)
@@ -448,40 +490,40 @@ directParameterDocumentation parameterName =
         , eqT @field @[UUID] |> fmap (\Refl -> listParameter @UUID parameterName)
         ]
 
-requiredParameter :: forall a. ToSchema a => Text -> QueryParameterDocumentation
+requiredParameter :: forall a. (ToSchema a) => Text -> QueryParameterDocumentation
 requiredParameter parameterName =
-    let SchemaDocumentation { documentedSchema, documentedDefinitions } = declareSchemaDocumentation (Proxy @a)
-    in QueryParameterDocumentation
-        { parameterName
-        , parameterRequired = True
-        , parameterSchema = documentedSchema
-        , parameterDefinitions = documentedDefinitions
-        , parameterExplode = Nothing
-        }
+    let SchemaDocumentation{documentedSchema, documentedDefinitions} = declareSchemaDocumentation (Proxy @a)
+     in QueryParameterDocumentation
+            { parameterName
+            , parameterRequired = True
+            , parameterSchema = documentedSchema
+            , parameterDefinitions = documentedDefinitions
+            , parameterExplode = Nothing
+            }
 
-optionalParameter :: forall a. ToSchema a => Text -> QueryParameterDocumentation
+optionalParameter :: forall a. (ToSchema a) => Text -> QueryParameterDocumentation
 optionalParameter parameterName =
-    let SchemaDocumentation { documentedSchema, documentedDefinitions } = declareSchemaDocumentation (Proxy @a)
-    in QueryParameterDocumentation
-        { parameterName
-        , parameterRequired = False
-        , parameterSchema = documentedSchema
-        , parameterDefinitions = documentedDefinitions
-        , parameterExplode = Nothing
-        }
+    let SchemaDocumentation{documentedSchema, documentedDefinitions} = declareSchemaDocumentation (Proxy @a)
+     in QueryParameterDocumentation
+            { parameterName
+            , parameterRequired = False
+            , parameterSchema = documentedSchema
+            , parameterDefinitions = documentedDefinitions
+            , parameterExplode = Nothing
+            }
 
-listParameter :: forall a. ToSchema [a] => Text -> QueryParameterDocumentation
+listParameter :: forall a. (ToSchema [a]) => Text -> QueryParameterDocumentation
 listParameter parameterName =
-    let SchemaDocumentation { documentedSchema, documentedDefinitions } = declareSchemaDocumentation (Proxy @[a])
-    in QueryParameterDocumentation
-        { parameterName
-        , parameterRequired = False
-        , parameterSchema = documentedSchema
-        , parameterDefinitions = documentedDefinitions
-        , parameterExplode = Just False
-        }
+    let SchemaDocumentation{documentedSchema, documentedDefinitions} = declareSchemaDocumentation (Proxy @[a])
+     in QueryParameterDocumentation
+            { parameterName
+            , parameterRequired = False
+            , parameterSchema = documentedSchema
+            , parameterDefinitions = documentedDefinitions
+            , parameterExplode = Just False
+            }
 
-wrappedIdParameterDocumentation :: forall field. Data field => Text -> Maybe QueryParameterDocumentation
+wrappedIdParameterDocumentation :: forall field. (Data field) => Text -> Maybe QueryParameterDocumentation
 wrappedIdParameterDocumentation parameterName
     | dataTypeName (dataTypeOf (undefined :: field)) /= "IHP.ModelSupport.Types.Id'" = Nothing
     | otherwise =
@@ -489,9 +531,9 @@ wrappedIdParameterDocumentation parameterName
             |> listToMaybe
             >>= \constructor -> either (const Nothing) Just (deriveWrappedIdParameter @field constructor parameterName)
 
-deriveWrappedIdParameter :: forall field. Data field => Constr -> Text -> Either Text QueryParameterDocumentation
+deriveWrappedIdParameter :: forall field. (Data field) => Constr -> Text -> Either Text QueryParameterDocumentation
 deriveWrappedIdParameter constructor parameterName =
-    let nextField :: forall inner. Data inner => State.StateT (Maybe QueryParameterDocumentation) (Either Text) inner
+    let nextField :: forall inner. (Data inner) => State.StateT (Maybe QueryParameterDocumentation) (Either Text) inner
         nextField = do
             parameter <- case queryParameterDocumentation @inner parameterName of
                 Just queryParameter -> pure queryParameter
@@ -502,38 +544,39 @@ deriveWrappedIdParameter constructor parameterName =
                 Left errorMessage -> State.lift (Left errorMessage)
         unsupportedInnerTypeMessage =
             "OpenAPI does not support the inner primary key type of "
-            <> parameterName
-    in case State.runStateT (fromConstrM nextField constructor :: State.StateT (Maybe QueryParameterDocumentation) (Either Text) field) Nothing of
-        Right (_, Just parameter) -> Right parameter
-        Right (_, Nothing) -> Left ("OpenAPI could not derive the inner primary key type of " <> parameterName)
-        Left errorMessage -> Left errorMessage
+                <> parameterName
+     in case State.runStateT (fromConstrM nextField constructor :: State.StateT (Maybe QueryParameterDocumentation) (Either Text) field) Nothing of
+            Right (_, Just parameter) -> Right parameter
+            Right (_, Nothing) -> Left ("OpenAPI could not derive the inner primary key type of " <> parameterName)
+            Left errorMessage -> Left errorMessage
 
-dummyValueForFieldType :: forall field. Data field => Either Text field
+dummyValueForFieldType :: forall field. (Data field) => Either Text field
 dummyValueForFieldType =
     fromMaybe
         (Left unsupportedDummyTypeMessage)
         (directDummyValue @field <|> wrappedIdDummyValue @field)
-    where
-        unsupportedDummyTypeMessage =
-            "OpenAPI dummy value is not implemented for type "
+  where
+    unsupportedDummyTypeMessage =
+        "OpenAPI dummy value is not implemented for type "
             <> cs (dataTypeName (dataTypeOf (undefined :: field)))
 
-directDummyValue :: forall field. Data field => Maybe (Either Text field)
-directDummyValue = asum
-    [ eqT @field @Text |> fmap (\Refl -> Right "")
-    , eqT @field @Int |> fmap (\Refl -> Right 0)
-    , eqT @field @Integer |> fmap (\Refl -> Right 0)
-    , eqT @field @UUID |> fmap (\Refl -> Right nil)
-    , eqT @field @(Maybe Text) |> fmap (\Refl -> Right Nothing)
-    , eqT @field @(Maybe Int) |> fmap (\Refl -> Right Nothing)
-    , eqT @field @(Maybe Integer) |> fmap (\Refl -> Right Nothing)
-    , eqT @field @[Text] |> fmap (\Refl -> Right [])
-    , eqT @field @[Int] |> fmap (\Refl -> Right [])
-    , eqT @field @[Integer] |> fmap (\Refl -> Right [])
-    , eqT @field @[UUID] |> fmap (\Refl -> Right [])
-    ]
+directDummyValue :: forall field. (Data field) => Maybe (Either Text field)
+directDummyValue =
+    asum
+        [ eqT @field @Text |> fmap (\Refl -> Right "")
+        , eqT @field @Int |> fmap (\Refl -> Right 0)
+        , eqT @field @Integer |> fmap (\Refl -> Right 0)
+        , eqT @field @UUID |> fmap (\Refl -> Right nil)
+        , eqT @field @(Maybe Text) |> fmap (\Refl -> Right Nothing)
+        , eqT @field @(Maybe Int) |> fmap (\Refl -> Right Nothing)
+        , eqT @field @(Maybe Integer) |> fmap (\Refl -> Right Nothing)
+        , eqT @field @[Text] |> fmap (\Refl -> Right [])
+        , eqT @field @[Int] |> fmap (\Refl -> Right [])
+        , eqT @field @[Integer] |> fmap (\Refl -> Right [])
+        , eqT @field @[UUID] |> fmap (\Refl -> Right [])
+        ]
 
-wrappedIdDummyValue :: forall field. Data field => Maybe (Either Text field)
+wrappedIdDummyValue :: forall field. (Data field) => Maybe (Either Text field)
 wrappedIdDummyValue
     | dataTypeName (dataTypeOf (undefined :: field)) /= "IHP.ModelSupport.Types.Id'" = Nothing
     | otherwise =
@@ -541,33 +584,33 @@ wrappedIdDummyValue
             |> listToMaybe
             |> fmap deriveWrappedIdDummyValue
 
-deriveWrappedIdDummyValue :: forall field. Data field => Constr -> Either Text field
+deriveWrappedIdDummyValue :: forall field. (Data field) => Constr -> Either Text field
 deriveWrappedIdDummyValue constructor =
-    let nextField :: forall inner. Data inner => State.StateT () (Either Text) inner
+    let nextField :: forall inner. (Data inner) => State.StateT () (Either Text) inner
         nextField =
             case dummyValueForFieldType @inner of
                 Right dummyValue -> pure dummyValue
                 Left errorMessage -> State.lift (Left errorMessage)
-    in fst <$> State.runStateT (fromConstrM nextField constructor :: State.StateT () (Either Text) field) ()
+     in fst <$> State.runStateT (fromConstrM nextField constructor :: State.StateT () (Either Text) field) ()
 
-buildDummyAction :: forall controller. Data controller => Constr -> Either Text controller
+buildDummyAction :: forall controller. (Data controller) => Constr -> Either Text controller
 buildDummyAction constructor =
-    let nextField :: forall field. Data field => State.StateT () (Either Text) field
+    let nextField :: forall field. (Data field) => State.StateT () (Either Text) field
         nextField = State.lift (dummyValueForFieldType @field)
-    in fst <$> State.runStateT (fromConstrM nextField constructor :: State.StateT () (Either Text) controller) ()
+     in fst <$> State.runStateT (fromConstrM nextField constructor :: State.StateT () (Either Text) controller) ()
 
 actionUsesCustomPath :: forall controller. (AutoRoute controller, Data controller) => Constr -> Either Text Bool
 actionUsesCustomPath constructor = isJust . customPathTo <$> buildDummyAction @controller constructor
 
-deriveActionParameters :: forall controller. Data controller => Constr -> Either Text [QueryParameterDocumentation]
+deriveActionParameters :: forall controller. (Data controller) => Constr -> Either Text [QueryParameterDocumentation]
 deriveActionParameters constr =
     let initialState = (map cs (constrFields constr), [])
-        nextField :: forall field. Data field => State.StateT ([Text], [QueryParameterDocumentation]) (Either Text) field
+        nextField :: forall field. (Data field) => State.StateT ([Text], [QueryParameterDocumentation]) (Either Text) field
         nextField = do
             (remainingFields, parameters) <- State.get
             case remainingFields of
                 [] -> State.lift (Left ("OpenAPI field derivation failed for action " <> cs (showConstr constr)))
-                (fieldName:restFields) ->
+                (fieldName : restFields) ->
                     case queryParameterDocumentation @field fieldName of
                         Just parameter -> do
                             State.put (restFields, parameters <> [parameter])
@@ -575,19 +618,19 @@ deriveActionParameters constr =
                                 Right dummyValue -> pure dummyValue
                                 Left errorMessage -> State.lift (Left errorMessage)
                         Nothing -> State.lift (Left unsupportedTypeMessage)
-                    where
-                        unsupportedTypeMessage =
-                            "OpenAPI does not support the AutoRoute field "
+                  where
+                    unsupportedTypeMessage =
+                        "OpenAPI does not support the AutoRoute field "
                             <> fieldName
                             <> " with type "
                             <> cs (dataTypeName (dataTypeOf (undefined :: field)))
-    in case State.runStateT
+     in case State.runStateT
             (fromConstrM nextField constr :: State.StateT ([Text], [QueryParameterDocumentation]) (Either Text) controller)
             initialState of
-        Left errorMessage -> Left errorMessage
-        Right (_, ([], parameters)) -> Right parameters
-        Right (_, (remainingFields, _)) ->
-            Left ("OpenAPI field derivation did not consume all fields for action " <> cs (showConstr constr) <> ": " <> cs (show remainingFields) :: Text)
+            Left errorMessage -> Left errorMessage
+            Right (_, ([], parameters)) -> Right parameters
+            Right (_, (remainingFields, _)) ->
+                Left ("OpenAPI field derivation did not consume all fields for action " <> cs (showConstr constr) <> ": " <> cs (show remainingFields) :: Text)
 
 instance {-# OVERLAPPABLE #-} (KnownSymbol table, ToSchema (PrimaryKey table)) => ToSchema (Id' table) where
     declareNamedSchema _ = declareNamedSchema (Proxy @(PrimaryKey table))

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -14,6 +14,7 @@ module IHP.RouterSupport (
     OpenApiController (..),
     documentRoute,
     ActionDoc (..),
+    OpenApiRequestBodyDoc (..),
     actionDoc,
     setOpenApiSummary,
     setOpenApiDescription,

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -26,7 +26,6 @@ module IHP.RouterSupport (
     setOpenApiDescription,
     setOpenApiTags,
     setOpenApiOperationId,
-    setOpenApiRequestBody,
     decodeActionRequestBody,
     runAction,
     get,
@@ -239,8 +238,21 @@ actionDocForRequestBody ::
     ) =>
     ActionDoc controller
 actionDocForRequestBody =
-    actionDocFor @actionName @view @controller
-        |> setOpenApiRequestBody @(OpenApiRequestBody controller actionName)
+    ActionDoc
+        { actionDocName = cs (symbolVal (Proxy @actionName))
+        , actionDocSummary = Nothing
+        , actionDocDescription = Nothing
+        , actionDocTags = []
+        , actionDocOperationId = Nothing
+        , actionDocView = Proxy @view
+        , actionDocTypedJson = JSON.toJSON . ViewSupport.jsonTyped
+        , actionDocRequestBody =
+            Just
+                OpenApiRequestBodyDoc
+                    { requestBodyRequired = openApiRequestBodyRequired @controller @actionName
+                    , requestBodySchema = Proxy @(OpenApiRequestBody controller actionName)
+                    }
+        }
 {-# INLINE actionDocForRequestBody #-}
 
 setOpenApiSummary :: Text -> ActionDoc controller -> ActionDoc controller
@@ -298,25 +310,6 @@ setOpenApiOperationId operationId ActionDoc{actionDocName, actionDocSummary, act
         , actionDocRequestBody
         }
 {-# INLINE setOpenApiOperationId #-}
-
-setOpenApiRequestBody :: forall body controller. (ToSchema body) => ActionDoc controller -> ActionDoc controller
-setOpenApiRequestBody ActionDoc{actionDocName, actionDocSummary, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson} =
-    ActionDoc
-        { actionDocName
-        , actionDocSummary
-        , actionDocDescription
-        , actionDocTags
-        , actionDocOperationId
-        , actionDocView
-        , actionDocTypedJson
-        , actionDocRequestBody =
-            Just
-                OpenApiRequestBodyDoc
-                    { requestBodyRequired = True
-                    , requestBodySchema = Proxy @body
-                    }
-        }
-{-# INLINE setOpenApiRequestBody #-}
 
 decodeActionRequestBody ::
     forall controller actionName.

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -312,12 +312,18 @@ setOpenApiOperationId operationId ActionDoc{actionDocName, actionDocSummary, act
 {-# INLINE setOpenApiOperationId #-}
 
 decodeActionRequestBody ::
-    forall controller actionName.
+    forall actionName controller.
     ( HasOpenApiRequestBody controller actionName
+    , Data controller
     , ?request :: Request
+    , ?theAction :: controller
     ) =>
     IO (Either String (OpenApiRequestBody controller actionName))
-decodeActionRequestBody =
+decodeActionRequestBody = do
+    let expectedActionName = symbolVal (Proxy @actionName)
+    let actualActionName = showConstr (toConstr ?theAction)
+    unless (actualActionName == expectedActionName) do
+        fail ("decodeActionRequestBody expected action " <> expectedActionName <> " but current action is " <> actualActionName)
     JSON.eitherDecode <$> getRequestBody
 {-# INLINE decodeActionRequestBody #-}
 

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -1,137 +1,147 @@
-{-# LANGUAGE AllowAmbiguousTypes, UndecidableInstances, LambdaCase, ScopedTypeVariables, GADTs #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module IHP.RouterSupport (
-CanRoute (..)
-, HasPath (..)
-, AutoRoute (..)
-, RouteInspection (..)
-, RouteDocumentation (..)
-, DocumentedRouteInfo (..)
-, OpenApiController (..)
-, documentRoute
-, ActionDoc (..)
-, actionDoc
-, setOpenApiSummary
-, setOpenApiDescription
-, setOpenApiTags
-, setOpenApiOperationId
-, runAction
-, get
-, post
-, startPage
-, frontControllerToWAIApp
-, withPrefix
-, FrontController (..)
-, defaultRouter
-, parseRoute
-, catchAll
-, mountFrontController
-, createAction
-, updateAction
-, urlTo
-, actionPrefixText
-, parseUUID
-, parseId
-, parseIntegerId
-, remainingText
-, parseText
-, webSocketApp
-, webSocketAppWithCustomPath
-, webSocketAppWithHTTPFallback
-, onlyAllowMethods
-, getMethod
-, routeParam
-, withImplicits
-, rawRoute
-, validateOpenApiRenderedView
-, applyConstr
-, ControllerRoute (..)
-, findInRouteMaps
-, buildAutoRouteMap
-, stripActionSuffixText
+    CanRoute (..),
+    HasPath (..),
+    AutoRoute (..),
+    RouteInspection (..),
+    RouteDocumentation (..),
+    DocumentedRouteInfo (..),
+    OpenApiController (..),
+    documentRoute,
+    ActionDoc (..),
+    actionDoc,
+    setOpenApiSummary,
+    setOpenApiDescription,
+    setOpenApiTags,
+    setOpenApiOperationId,
+    setOpenApiRequestBody,
+    runAction,
+    get,
+    post,
+    startPage,
+    frontControllerToWAIApp,
+    withPrefix,
+    FrontController (..),
+    defaultRouter,
+    parseRoute,
+    catchAll,
+    mountFrontController,
+    createAction,
+    updateAction,
+    urlTo,
+    actionPrefixText,
+    parseUUID,
+    parseId,
+    parseIntegerId,
+    remainingText,
+    parseText,
+    webSocketApp,
+    webSocketAppWithCustomPath,
+    webSocketAppWithHTTPFallback,
+    onlyAllowMethods,
+    getMethod,
+    routeParam,
+    withImplicits,
+    rawRoute,
+    validateOpenApiRenderedView,
+    applyConstr,
+    ControllerRoute (..),
+    findInRouteMaps,
+    buildAutoRouteMap,
+    stripActionSuffixText,
 ) where
 
-import Prelude hiding (take)
-import Data.ByteString (ByteString)
-import Data.Text (Text)
-import Data.Maybe (fromMaybe, mapMaybe)
-import Data.List (find, isPrefixOf)
-import Control.Monad (unless, join)
-import Control.Applicative ((<|>), empty)
-import Text.Read (readMaybe)
-import Control.Exception.Safe (SomeException, catch, throwIO)
+import Control.Applicative (empty, (<|>))
 import Control.Exception (evaluate)
-import qualified IHP.ModelSupport as ModelSupport
-import IHP.FrameworkConfig
-import Data.UUID
-import Network.HTTP.Types.Method
-import Network.Wai
-import IHP.ControllerSupport
-import Data.Attoparsec.ByteString.Char8 (string, Parser, parseOnly, take, endOfInput, choice, takeTill, takeByteString)
-import qualified Data.Attoparsec.ByteString.Char8 as Attoparsec
-import GHC.TypeLits
+import Control.Exception qualified as Exception
+import Control.Exception.Safe (SomeException, catch, throwIO)
+import Control.Monad (join, unless)
+import Control.Monad.State.Strict qualified as State
+import Data.Aeson qualified as JSON
+import Data.Attoparsec.ByteString.Char8 (Parser, choice, endOfInput, parseOnly, string, take, takeByteString, takeTill)
+import Data.Attoparsec.ByteString.Char8 qualified as Attoparsec
+import Data.ByteString (ByteString)
+import Data.ByteString.Char8 qualified as ByteString
 import Data.Data
-import qualified Control.Monad.State.Strict as State
-import qualified Data.Text as Text
-import Network.HTTP.Types.URI
-import qualified Data.List as List
-import Unsafe.Coerce
-import IHP.HaskellSupport hiding (get)
-import qualified Data.Typeable as Typeable
-import qualified Data.ByteString.Char8 as ByteString
-import Data.String.Conversions (ConvertibleStrings (convertString), cs)
-import qualified Text.Blaze.Html5 as Html5
-import qualified Control.Exception as Exception
-import qualified Data.Aeson as JSON
-import qualified IHP.ErrorController as ErrorController
-import qualified Network.URI.Encode as URI
-import qualified Data.Text.Encoding as Text
 import Data.Dynamic
-import IHP.Router.Types
-import IHP.Router.UrlGenerator
-import qualified Data.HashMap.Strict as HashMap
-import IHP.WebSocket (WSApp)
-import qualified IHP.WebSocket as WS
+import Data.HashMap.Strict qualified as HashMap
+import Data.Kind
+import Data.List (find, isPrefixOf)
+import Data.List qualified as List
+import Data.Maybe (fromMaybe, mapMaybe)
+import Data.OpenApi (ToSchema)
+import Data.String.Conversions (ConvertibleStrings (convertString), cs)
+import Data.TMap qualified as TypeMap
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Typeable qualified as Typeable
+import Data.UUID
+import Data.Vault.Lazy qualified as Vault
+import GHC.TypeLits
 import GHC.TypeLits as T
 import IHP.Controller.Context
 import IHP.Controller.Param
-import Data.Kind
-import qualified Data.TMap as TypeMap
-import Data.OpenApi (ToSchema)
-import qualified IHP.ViewSupport as ViewSupport
-import qualified Data.Vault.Lazy as Vault
-import System.IO.Unsafe (unsafePerformIO)
+import IHP.ControllerSupport
+import IHP.ErrorController qualified as ErrorController
+import IHP.FrameworkConfig
+import IHP.HaskellSupport hiding (get)
+import IHP.ModelSupport qualified as ModelSupport
+import IHP.Router.Types
+import IHP.Router.UrlGenerator
+import IHP.ViewSupport qualified as ViewSupport
+import IHP.WebSocket (WSApp)
+import IHP.WebSocket qualified as WS
 import Network.HTTP.Types.Header (hContentType)
+import Network.HTTP.Types.Method
 import Network.HTTP.Types.Status (status400, status500)
+import Network.HTTP.Types.URI
+import Network.URI.Encode qualified as URI
+import Network.Wai
 import Network.Wai.Middleware.EarlyReturn (earlyReturnMiddleware)
+import System.IO.Unsafe (unsafePerformIO)
+import Text.Blaze.Html5 qualified as Html5
+import Text.Read (readMaybe)
+import Unsafe.Coerce
+import Prelude hiding (take)
 
--- | Binds @?request@ and @?respond@ from WAI arguments, then runs the given action.
---
--- This avoids repeating @let ?request = waiRequest; let ?respond = waiRespond@ at each call site.
+{- | Binds @?request@ and @?respond@ from WAI arguments, then runs the given action.
+
+This avoids repeating @let ?request = waiRequest; let ?respond = waiRespond@ at each call site.
+-}
 {-# INLINE withImplicits #-}
 withImplicits :: ((?request :: Request, ?respond :: Respond) => Application) -> Application
 withImplicits action waiRequest waiRespond =
     let ?request = waiRequest
         ?respond = waiRespond
-    in action waiRequest waiRespond
+     in action waiRequest waiRespond
 
-runAction'
-    :: forall application controller
-     . ( Controller controller
-       , InitControllerContext application
-       , ?application :: application
-       , Typeable application
-       , Typeable controller
-       )
-     => controller -> Application
+runAction' ::
+    forall application controller.
+    ( Controller controller
+    , InitControllerContext application
+    , ?application :: application
+    , Typeable application
+    , Typeable controller
+    ) =>
+    controller -> Application
 runAction' controller waiRequest waiRespond =
-    earlyReturnMiddleware (\request respond -> do
-        context <- setupActionContext @application (Typeable.typeOf controller) request respond
-        let ?context = context
-        let ?respond = respond
-        let ?request = context.request
-        let ?modelContext = ?request.modelContext
-        runAction controller
-        ) waiRequest waiRespond
+    earlyReturnMiddleware
+        ( \request respond -> do
+            context <- setupActionContext @application (Typeable.typeOf controller) request respond
+            let ?context = context
+            let ?respond = respond
+            let ?request = context.request
+            let ?modelContext = ?request.modelContext
+            runAction controller
+        )
+        waiRequest
+        waiRespond
 {-# INLINE runAction' #-}
 
 data ActionDoc controller where
@@ -141,83 +151,124 @@ data ActionDoc controller where
         , Typeable.Typeable view
         , JSON.ToJSON (ViewSupport.JsonResponse view)
         , ToSchema (ViewSupport.JsonResponse view)
-        )
-        => { actionDocName :: Text
-           , actionDocSummary :: Maybe Text
-           , actionDocDescription :: Maybe Text
-           , actionDocTags :: [Text]
-           , actionDocOperationId :: Maybe Text
-           , actionDocView :: Proxy view
-           , actionDocTypedJson :: view -> JSON.Value
-           } -> ActionDoc controller
+        ) =>
+        { actionDocName :: Text
+        , actionDocSummary :: Maybe Text
+        , actionDocDescription :: Maybe Text
+        , actionDocTags :: [Text]
+        , actionDocOperationId :: Maybe Text
+        , actionDocView :: Proxy view
+        , actionDocTypedJson :: view -> JSON.Value
+        , actionDocRequestBody :: Maybe OpenApiRequestBodyDoc
+        } ->
+        ActionDoc controller
 
-actionDoc :: forall view controller.
+data OpenApiRequestBodyDoc where
+    OpenApiRequestBodyDoc ::
+        forall body.
+        (ToSchema body) =>
+        { requestBodyRequired :: Bool
+        , requestBodySchema :: Proxy body
+        } ->
+        OpenApiRequestBodyDoc
+
+actionDoc ::
+    forall view controller.
     ( ViewSupport.View view
     , Typeable.Typeable view
     , JSON.ToJSON (ViewSupport.JsonResponse view)
     , ToSchema (ViewSupport.JsonResponse view)
-    )
-    => Text -> ActionDoc controller
-actionDoc actionName = ActionDoc
-    { actionDocName = actionName
-    , actionDocSummary = Nothing
-    , actionDocDescription = Nothing
-    , actionDocTags = []
-    , actionDocOperationId = Nothing
-    , actionDocView = Proxy @view
-    , actionDocTypedJson = JSON.toJSON . ViewSupport.jsonTyped
-    }
+    ) =>
+    Text -> ActionDoc controller
+actionDoc actionName =
+    ActionDoc
+        { actionDocName = actionName
+        , actionDocSummary = Nothing
+        , actionDocDescription = Nothing
+        , actionDocTags = []
+        , actionDocOperationId = Nothing
+        , actionDocView = Proxy @view
+        , actionDocTypedJson = JSON.toJSON . ViewSupport.jsonTyped
+        , actionDocRequestBody = Nothing
+        }
 {-# INLINE actionDoc #-}
 
 setOpenApiSummary :: Text -> ActionDoc controller -> ActionDoc controller
-setOpenApiSummary summary ActionDoc { actionDocName, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson } = ActionDoc
-    { actionDocName
-    , actionDocSummary = Just summary
-    , actionDocDescription
-    , actionDocTags
-    , actionDocOperationId
-    , actionDocView
-    , actionDocTypedJson
-    }
+setOpenApiSummary summary ActionDoc{actionDocName, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson, actionDocRequestBody} =
+    ActionDoc
+        { actionDocName
+        , actionDocSummary = Just summary
+        , actionDocDescription
+        , actionDocTags
+        , actionDocOperationId
+        , actionDocView
+        , actionDocTypedJson
+        , actionDocRequestBody
+        }
 {-# INLINE setOpenApiSummary #-}
 
 setOpenApiDescription :: Text -> ActionDoc controller -> ActionDoc controller
-setOpenApiDescription description ActionDoc { actionDocName, actionDocSummary, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson } = ActionDoc
-    { actionDocName
-    , actionDocSummary
-    , actionDocDescription = Just description
-    , actionDocTags
-    , actionDocOperationId
-    , actionDocView
-    , actionDocTypedJson
-    }
+setOpenApiDescription description ActionDoc{actionDocName, actionDocSummary, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson, actionDocRequestBody} =
+    ActionDoc
+        { actionDocName
+        , actionDocSummary
+        , actionDocDescription = Just description
+        , actionDocTags
+        , actionDocOperationId
+        , actionDocView
+        , actionDocTypedJson
+        , actionDocRequestBody
+        }
 {-# INLINE setOpenApiDescription #-}
 
 setOpenApiTags :: [Text] -> ActionDoc controller -> ActionDoc controller
-setOpenApiTags tags ActionDoc { actionDocName, actionDocSummary, actionDocDescription, actionDocOperationId, actionDocView, actionDocTypedJson } = ActionDoc
-    { actionDocName
-    , actionDocSummary
-    , actionDocDescription
-    , actionDocTags = tags
-    , actionDocOperationId
-    , actionDocView
-    , actionDocTypedJson
-    }
+setOpenApiTags tags ActionDoc{actionDocName, actionDocSummary, actionDocDescription, actionDocOperationId, actionDocView, actionDocTypedJson, actionDocRequestBody} =
+    ActionDoc
+        { actionDocName
+        , actionDocSummary
+        , actionDocDescription
+        , actionDocTags = tags
+        , actionDocOperationId
+        , actionDocView
+        , actionDocTypedJson
+        , actionDocRequestBody
+        }
 {-# INLINE setOpenApiTags #-}
 
 setOpenApiOperationId :: Text -> ActionDoc controller -> ActionDoc controller
-setOpenApiOperationId operationId ActionDoc { actionDocName, actionDocSummary, actionDocDescription, actionDocTags, actionDocView, actionDocTypedJson } = ActionDoc
-    { actionDocName
-    , actionDocSummary
-    , actionDocDescription
-    , actionDocTags
-    , actionDocOperationId = Just operationId
-    , actionDocView
-    , actionDocTypedJson
-    }
+setOpenApiOperationId operationId ActionDoc{actionDocName, actionDocSummary, actionDocDescription, actionDocTags, actionDocView, actionDocTypedJson, actionDocRequestBody} =
+    ActionDoc
+        { actionDocName
+        , actionDocSummary
+        , actionDocDescription
+        , actionDocTags
+        , actionDocOperationId = Just operationId
+        , actionDocView
+        , actionDocTypedJson
+        , actionDocRequestBody
+        }
 {-# INLINE setOpenApiOperationId #-}
 
-class AutoRoute controller => OpenApiController controller where
+setOpenApiRequestBody :: forall body controller. (ToSchema body) => ActionDoc controller -> ActionDoc controller
+setOpenApiRequestBody ActionDoc{actionDocName, actionDocSummary, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson} =
+    ActionDoc
+        { actionDocName
+        , actionDocSummary
+        , actionDocDescription
+        , actionDocTags
+        , actionDocOperationId
+        , actionDocView
+        , actionDocTypedJson
+        , actionDocRequestBody =
+            Just
+                OpenApiRequestBodyDoc
+                    { requestBodyRequired = True
+                    , requestBodySchema = Proxy @body
+                    }
+        }
+{-# INLINE setOpenApiRequestBody #-}
+
+class (AutoRoute controller) => OpenApiController controller where
     openApiActions :: [ActionDoc controller]
 
 data DocumentedRouteInfo where
@@ -226,9 +277,10 @@ data DocumentedRouteInfo where
         ( AutoRoute controller
         , Data controller
         , Typeable.Typeable controller
-        )
-        => { documentedActions :: Maybe [ActionDoc controller]
-           } -> DocumentedRouteInfo
+        ) =>
+        { documentedActions :: Maybe [ActionDoc controller]
+        } ->
+        DocumentedRouteInfo
 
 data RouteDocumentation
     = UndocumentedRoute
@@ -251,34 +303,35 @@ data ControllerRoute application
         }
 
 rawRoute :: Parser Application -> ControllerRoute application
-rawRoute parser = ControllerRouteParser { routeParser = parser, routeInspection = RouteLeaf UndocumentedRoute }
+rawRoute parser = ControllerRouteParser{routeParser = parser, routeInspection = RouteLeaf UndocumentedRoute}
 {-# INLINE rawRoute #-}
 
 compileControllerRoute :: ControllerRoute application -> Parser Application
-compileControllerRoute ControllerRouteMap { routeParser } = routeParser
-compileControllerRoute ControllerRouteParser { routeParser } = routeParser
+compileControllerRoute ControllerRouteMap{routeParser} = routeParser
+compileControllerRoute ControllerRouteParser{routeParser} = routeParser
 {-# INLINE compileControllerRoute #-}
 
--- | Catches exceptions from routing and rethrows them wrapped in
--- 'RouterException' so the error handler middleware can distinguish
--- routing failures from action failures.
+{- | Catches exceptions from routing and rethrows them wrapped in
+'RouterException' so the error handler middleware can distinguish
+routing failures from action failures.
+-}
 wrapRouterException :: IO a -> IO a
 wrapRouterException action = action `catch` \(e :: SomeException) -> throwIO (ErrorController.RouterException e)
 
 class FrontController application where
-    controllers
-        :: (?application :: application, ?request :: Request, ?respond :: Respond)
-        => [ControllerRoute application]
+    controllers ::
+        (?application :: application, ?request :: Request, ?respond :: Respond) =>
+        [ControllerRoute application]
 
-    router
-        :: (?application :: application, ?request :: Request, ?respond :: Respond)
-        => [ControllerRoute application] -> Parser Application
+    router ::
+        (?application :: application, ?request :: Request, ?respond :: Respond) =>
+        [ControllerRoute application] -> Parser Application
     router = defaultRouter
-    {-# INLINABLE router #-}
+    {-# INLINEABLE router #-}
 
-defaultRouter
-    :: (?application :: application, ?request :: Request, ?respond :: Respond, FrontController application)
-    => [ControllerRoute application] -> Parser Application
+defaultRouter ::
+    (?application :: application, ?request :: Request, ?respond :: Respond, FrontController application) =>
+    [ControllerRoute application] -> Parser Application
 defaultRouter additionalRoutes = do
     let allRoutes = controllers <> additionalRoutes
         path = rawPathInfo ?request
@@ -289,13 +342,14 @@ defaultRouter additionalRoutes = do
             -- Slow path: fall back to Attoparsec parsers for custom/dynamic routes
             let parsers = concatMap getRouteParsers allRoutes
             choice (map (<* endOfInput) parsers)
-{-# INLINABLE defaultRouter #-}
+{-# INLINEABLE defaultRouter #-}
 
--- | Scan 'ControllerRouteMap' entries for a matching path.
--- Returns as soon as a HashMap contains the path. Skips 'ControllerRouteParser' entries.
+{- | Scan 'ControllerRouteMap' entries for a matching path.
+Returns as soon as a HashMap contains the path. Skips 'ControllerRouteParser' entries.
+-}
 findInRouteMaps :: ByteString -> [ControllerRoute application] -> Maybe (application -> Application)
 findInRouteMaps _ [] = Nothing
-findInRouteMaps path (ControllerRouteMap { routeMap } : rest) =
+findInRouteMaps path (ControllerRouteMap{routeMap} : rest) =
     case HashMap.lookup path routeMap of
         Just handler -> Just handler
         Nothing -> findInRouteMaps path rest
@@ -303,8 +357,9 @@ findInRouteMaps path (_ : rest) = findInRouteMaps path rest
 
 -- | Extract fallback parsers from controller routes.
 getRouteParsers :: ControllerRoute application -> [Parser Application]
-getRouteParsers ControllerRouteMap { routeParser } = [routeParser]
-getRouteParsers ControllerRouteParser { routeParser } = [routeParser]
+getRouteParsers ControllerRouteMap{routeParser} = [routeParser]
+getRouteParsers ControllerRouteParser{routeParser} = [routeParser]
+
 data DocumentedRenderExpectation = DocumentedRenderExpectation
     { expectedViewTypeName :: Text
     , expectedTypedJson :: Dynamic -> Maybe JSON.Value
@@ -319,96 +374,105 @@ throwOpenApiRenderMismatch message =
     respondAndExit (responseLBS status500 [(hContentType, "text/plain")] (cs message))
 {-# INLINE throwOpenApiRenderMismatch #-}
 
-validateOpenApiRenderedView
-    :: forall view.
-        ( Typeable.Typeable view
-        , ?request :: Request
-        , ?respond :: Respond
-        )
-    => view
-    -> JSON.Value
-    -> IO ()
+validateOpenApiRenderedView ::
+    forall view.
+    ( Typeable.Typeable view
+    , ?request :: Request
+    , ?respond :: Respond
+    ) =>
+    view ->
+    JSON.Value ->
+    IO ()
 validateOpenApiRenderedView view actualJson =
     case Vault.lookup openApiRenderExpectationKey ?request.vault of
         Nothing -> pure ()
-        Just DocumentedRenderExpectation { expectedViewTypeName, expectedTypedJson } ->
+        Just DocumentedRenderExpectation{expectedViewTypeName, expectedTypedJson} ->
             let renderedViewTypeName = cs (show (Typeable.typeRep (Proxy @view)))
-            in unless (renderedViewTypeName == expectedViewTypeName)
-                (throwOpenApiRenderMismatch ("OpenAPI docs expect view " <> cs expectedViewTypeName <> ", but render produced " <> cs renderedViewTypeName))
-            >> case expectedTypedJson (toDyn view) of
-                Nothing ->
-                    throwOpenApiRenderMismatch ("OpenAPI docs could not validate the typed JSON for view " <> cs expectedViewTypeName)
-                Just expectedJson ->
-                    unless (actualJson == expectedJson)
-                        (throwOpenApiRenderMismatch ("OpenAPI docs expect the JSON generated from jsonTyped of view " <> cs expectedViewTypeName <> ", but render produced a different JSON value"))
+             in unless
+                    (renderedViewTypeName == expectedViewTypeName)
+                    (throwOpenApiRenderMismatch ("OpenAPI docs expect view " <> cs expectedViewTypeName <> ", but render produced " <> cs renderedViewTypeName))
+                    >> case expectedTypedJson (toDyn view) of
+                        Nothing ->
+                            throwOpenApiRenderMismatch ("OpenAPI docs could not validate the typed JSON for view " <> cs expectedViewTypeName)
+                        Just expectedJson ->
+                            unless
+                                (actualJson == expectedJson)
+                                (throwOpenApiRenderMismatch ("OpenAPI docs expect the JSON generated from jsonTyped of view " <> cs expectedViewTypeName <> ", but render produced a different JSON value"))
 {-# INLINE validateOpenApiRenderedView #-}
 
-documentedRenderExpectationForAction :: forall controller. Data controller => RouteDocumentation -> controller -> Maybe DocumentedRenderExpectation
+documentedRenderExpectationForAction :: forall controller. (Data controller) => RouteDocumentation -> controller -> Maybe DocumentedRenderExpectation
 documentedRenderExpectationForAction UndocumentedRoute _ = Nothing
-documentedRenderExpectationForAction (DocumentedRoute (AutoRouteControllerInfo { documentedActions = Nothing })) _ = Nothing
-documentedRenderExpectationForAction (DocumentedRoute (AutoRouteControllerInfo { documentedActions = Just docs })) action =
+documentedRenderExpectationForAction (DocumentedRoute (AutoRouteControllerInfo{documentedActions = Nothing})) _ = Nothing
+documentedRenderExpectationForAction (DocumentedRoute (AutoRouteControllerInfo{documentedActions = Just docs})) action =
     docs
-        |> find (\ActionDoc { actionDocName } -> actionDocName == cs (showConstr (toConstr action)))
-        |> fmap (\ActionDoc { actionDocView, actionDocTypedJson } -> DocumentedRenderExpectation
-            { expectedViewTypeName = cs (show (Typeable.typeRep actionDocView))
-            , expectedTypedJson = fmap actionDocTypedJson . fromDynamic
-            })
+        |> find (\ActionDoc{actionDocName} -> actionDocName == cs (showConstr (toConstr action)))
+        |> fmap
+            ( \ActionDoc{actionDocView, actionDocTypedJson} ->
+                DocumentedRenderExpectation
+                    { expectedViewTypeName = cs (show (Typeable.typeRep actionDocView))
+                    , expectedTypedJson = fmap actionDocTypedJson . fromDynamic
+                    }
+            )
 
-runActionWithRouteDocumentation
-    :: forall application controller.
-        ( Controller controller
-        , InitControllerContext application
-        , ?application :: application
-        , Typeable application
-        , Typeable controller
-        , Data controller
-        )
-    => RouteDocumentation
-    -> controller
-    -> Application
+runActionWithRouteDocumentation ::
+    forall application controller.
+    ( Controller controller
+    , InitControllerContext application
+    , ?application :: application
+    , Typeable application
+    , Typeable controller
+    , Data controller
+    ) =>
+    RouteDocumentation ->
+    controller ->
+    Application
 runActionWithRouteDocumentation routeDocumentation action waiRequest waiRespond =
     let renderExpectation = documentedRenderExpectationForAction routeDocumentation action
         waiRequest' = case renderExpectation of
-            Just expected -> waiRequest { vault = Vault.insert openApiRenderExpectationKey expected waiRequest.vault }
+            Just expected -> waiRequest{vault = Vault.insert openApiRenderExpectationKey expected waiRequest.vault}
             Nothing -> waiRequest
-    in runAction' @application action waiRequest' waiRespond
+     in runAction' @application action waiRequest' waiRespond
 {-# INLINE runActionWithRouteDocumentation #-}
 
--- | Returns the url to a given action.
---
--- Uses the baseUrl configured in @Config/Config.hs@. When no @baseUrl@
--- is configured in development mode, it will automatically detect the
--- correct @baseUrl@ value.
---
--- >>> urlTo UsersAction
--- "http://localhost:8000/Users"
---
--- >>> urlTo ShowUserAction { userId = "a32913dd-ef80-4f3e-9a91-7879e17b2ece" }
--- "http://localhost:8000/ShowUser?userId=a32913dd-ef80-4f3e-9a91-7879e17b2ece"
+{- | Returns the url to a given action.
+
+Uses the baseUrl configured in @Config/Config.hs@. When no @baseUrl@
+is configured in development mode, it will automatically detect the
+correct @baseUrl@ value.
+
+>>> urlTo UsersAction
+"http://localhost:8000/Users"
+
+>>> urlTo ShowUserAction { userId = "a32913dd-ef80-4f3e-9a91-7879e17b2ece" }
+"http://localhost:8000/ShowUser?userId=a32913dd-ef80-4f3e-9a91-7879e17b2ece"
+-}
 urlTo :: (?context :: context, ConfigProvider context, HasPath action) => action -> Text
 urlTo action = ?context.frameworkConfig.baseUrl <> pathTo action
 {-# INLINE urlTo #-}
 
-class HasPath controller => CanRoute controller where
+class (HasPath controller) => CanRoute controller where
     parseRoute' :: (?request :: Request, ?respond :: Respond) => Parser controller
 
-    -- | Builds a WAI Application parser for this controller.
-    --
-    -- The default implementation parses the controller action using 'parseRoute''
-    -- and applies the given callback. The overlappable 'AutoRoute' instance overrides
-    -- this to defer query string parsing and method validation to the Application closure.
+    {- | Builds a WAI Application parser for this controller.
+
+    The default implementation parses the controller action using 'parseRoute''
+    and applies the given callback. The overlappable 'AutoRoute' instance overrides
+    this to defer query string parsing and method validation to the Application closure.
+    -}
     parseRouteWithAction :: (?request :: Request, ?respond :: Respond) => (controller -> Application) -> Parser Application
     parseRouteWithAction toApp = do
         action <- parseRoute'
         pure (toApp action)
     {-# INLINE parseRouteWithAction #-}
 
-    -- | Build a 'ControllerRoute' for this controller.
-    --
-    -- The default wraps the parser in 'ControllerRouteParser'.
-    -- The overlappable 'AutoRoute' instance overrides this to use 'ControllerRouteMap'
-    -- for O(1) HashMap dispatch. This is what 'parseRoute' calls.
-    toControllerRoute :: forall application.
+    {- | Build a 'ControllerRoute' for this controller.
+
+    The default wraps the parser in 'ControllerRouteParser'.
+    The overlappable 'AutoRoute' instance overrides this to use 'ControllerRouteMap'
+    for O(1) HashMap dispatch. This is what 'parseRoute' calls.
+    -}
+    toControllerRoute ::
+        forall application.
         ( ?request :: Request
         , ?respond :: Respond
         , Controller controller
@@ -416,316 +480,324 @@ class HasPath controller => CanRoute controller where
         , ?application :: application
         , Typeable application
         , Typeable controller
-        ) => ControllerRoute application
-    toControllerRoute = ControllerRouteParser
-        { routeParser = parseRouteWithAction @controller (runAction' @application)
-        , routeInspection = RouteLeaf UndocumentedRoute
-        }
-    {-# INLINABLE toControllerRoute #-}
+        ) =>
+        ControllerRoute application
+    toControllerRoute =
+        ControllerRouteParser
+            { routeParser = parseRouteWithAction @controller (runAction' @application)
+            , routeInspection = RouteLeaf UndocumentedRoute
+            }
+    {-# INLINEABLE toControllerRoute #-}
 
+{- | Each of these is tried when trying to parse an argument to a controller constructor (i.e. in IHP, an action).
+The type @d@ is an the type of the argument, and all we know about this type that its conforms to @Data@.
+We cannot cast @d@ to some arbitrary type, since adding additional constraints to @d@ (such as Read)
+will break the @fromConstrM@ function which actually constructs the action.
 
--- | Each of these is tried when trying to parse an argument to a controller constructor (i.e. in IHP, an action).
--- The type @d@ is an the type of the argument, and all we know about this type that its conforms to @Data@.
--- We cannot cast @d@ to some arbitrary type, since adding additional constraints to @d@ (such as Read)
--- will break the @fromConstrM@ function which actually constructs the action.
---
--- The approach taken here is to make use of the type equality operator @:~:@
--- to check and see if @d@ happens to be a certain type. If it is,
--- by matching on Just Refl, we are able to use @d@ as the type we matched it to.
---
--- Please consult your doctor before engaging in Haskell type programming.
+The approach taken here is to make use of the type equality operator @:~:@
+to check and see if @d@ happens to be a certain type. If it is,
+by matching on Just Refl, we are able to use @d@ as the type we matched it to.
+
+Please consult your doctor before engaging in Haskell type programming.
+-}
 parseFuncs :: forall d idType. (Data d, Data idType) => (ByteString -> Maybe idType) -> [Maybe ByteString -> Either TypedAutoRouteError d]
-parseFuncs parseIdType = [
-            -- Try and parse @Int@ or @Maybe Int@
-            \case
-                Just queryValue -> case eqT :: Maybe (d :~: Int) of
-                    Just Refl -> case ByteString.readInt queryValue of
-                        Just (n, "") -> Right n
-                        _ -> Left BadType { field = "", value = Just queryValue, expectedType = "Int" }
-                    Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
-                        Just Refl -> Right $ case ByteString.readInt queryValue of
-                            Just (n, "") -> Just n
-                            _ -> Nothing
-                        Nothing -> Left NotMatched
-                Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
-                    Just Refl -> Right Nothing
-                    Nothing -> Left NotMatched,
-
-            \case
-                Just queryValue -> case eqT :: Maybe (d :~: Integer) of
-                    Just Refl -> case ByteString.readInteger queryValue of
-                        Just (n, "") -> Right n
-                        _ -> Left BadType { field = "", value = Just queryValue, expectedType = "Integer" }
-                    Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
-                        Just Refl -> Right $ case ByteString.readInteger queryValue of
-                            Just (n, "") -> Just n
-                            _ -> Nothing
-                        Nothing -> Left NotMatched
-                Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
-                    Just Refl -> Right Nothing
-                    Nothing -> Left NotMatched,
-
-            -- Try and parse @Text@ or @Maybe Text@
-            \case
-                Just queryValue -> case eqT :: Maybe (d :~: Text) of
-                    Just Refl -> Right $ cs queryValue
-                    Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
-                        Just Refl -> Right $ Just $ cs queryValue
-                        Nothing -> Left NotMatched
-                Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
-                    Just Refl -> Right Nothing
-                    Nothing -> Left NotMatched,
-            \case
-                Just queryValue -> case parseIdType queryValue of
-                    Just idValue -> case eqT :: Maybe (d :~: idType) of
-                        Just Refl -> Right idValue
-                        Nothing -> Left NotMatched
-                    Nothing -> Left NotMatched
-                Nothing -> Left NotMatched,
-
-            -- Try and parse @[Text]@. If value is not present then default to empty list.
-            \queryValue -> case eqT :: Maybe (d :~: [Text]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> Right $ Text.splitOn "," (cs queryValue)
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            -- Try and parse @[Int]@. If value is not present then default to empty list.
-            \queryValue -> case eqT :: Maybe (d :~: [Int]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> ByteString.split ',' queryValue
-                        |> mapMaybe (\b -> case ByteString.readInt b of Just (n, "") -> Just n; _ -> Nothing)
-                        |> Right
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            \queryValue -> case eqT :: Maybe (d :~: [Integer]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> ByteString.split ',' queryValue
-                        |> mapMaybe (\b -> case ByteString.readInteger b of Just (n, "") -> Just n; _ -> Nothing)
-                        |> Right
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            -- Try and parse a raw [UUID]
-            \queryValue -> case eqT :: Maybe (d :~: [UUID]) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> ByteString.split ',' queryValue
-                        |> mapMaybe fromASCIIBytes
-                        |> Right
-                    Nothing -> Right []
-                Nothing -> Left NotMatched,
-
-            -- Try and parse a raw UUID
-            \queryValue -> case eqT :: Maybe (d :~: UUID) of
-                Just Refl -> case queryValue of
-                    Just queryValue -> queryValue
-                        |> fromASCIIBytes
-                        |> \case
-                            Just uuid -> uuid |> Right
-                            Nothing -> Left BadType { field = "", value = Just queryValue, expectedType = "UUID" }
-                    Nothing -> Left NotMatched
-                Nothing -> Left NotMatched,
-
-            -- This has to be last parser in the list
-            --
-            -- Try and parse a UUID wrapped with a Id. In IHP types these are wrapped in a newtype @Id@ such as @Id User@.
-            -- Since @Id@ is a newtype wrapping a UUID, it has the same data representation in GHC.
-            -- Therefore, we're able to safely cast it to its @Id@ type with @unsafeCoerce@.
-            --
-            -- We cannot use 'eqT' here for checking the types, as it's wrapped inside the @Id@ type. We expect
-            -- that if it looks like a UUID, we can just treat it like an @Id@ type. For that to not overshadow other
-            -- parsers, we need to have this last.
-            \queryValue -> case queryValue of
-                Just queryValue -> queryValue
+parseFuncs parseIdType =
+    [ -- Try and parse @Int@ or @Maybe Int@
+      \case
+        Just queryValue -> case eqT :: Maybe (d :~: Int) of
+            Just Refl -> case ByteString.readInt queryValue of
+                Just (n, "") -> Right n
+                _ -> Left BadType{field = "", value = Just queryValue, expectedType = "Int"}
+            Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
+                Just Refl -> Right $ case ByteString.readInt queryValue of
+                    Just (n, "") -> Just n
+                    _ -> Nothing
+                Nothing -> Left NotMatched
+        Nothing -> case eqT :: Maybe (d :~: Maybe Int) of
+            Just Refl -> Right Nothing
+            Nothing -> Left NotMatched
+    , \case
+        Just queryValue -> case eqT :: Maybe (d :~: Integer) of
+            Just Refl -> case ByteString.readInteger queryValue of
+                Just (n, "") -> Right n
+                _ -> Left BadType{field = "", value = Just queryValue, expectedType = "Integer"}
+            Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
+                Just Refl -> Right $ case ByteString.readInteger queryValue of
+                    Just (n, "") -> Just n
+                    _ -> Nothing
+                Nothing -> Left NotMatched
+        Nothing -> case eqT :: Maybe (d :~: Maybe Integer) of
+            Just Refl -> Right Nothing
+            Nothing -> Left NotMatched
+    , -- Try and parse @Text@ or @Maybe Text@
+      \case
+        Just queryValue -> case eqT :: Maybe (d :~: Text) of
+            Just Refl -> Right $ cs queryValue
+            Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
+                Just Refl -> Right $ Just $ cs queryValue
+                Nothing -> Left NotMatched
+        Nothing -> case eqT :: Maybe (d :~: Maybe Text) of
+            Just Refl -> Right Nothing
+            Nothing -> Left NotMatched
+    , \case
+        Just queryValue -> case parseIdType queryValue of
+            Just idValue -> case eqT :: Maybe (d :~: idType) of
+                Just Refl -> Right idValue
+                Nothing -> Left NotMatched
+            Nothing -> Left NotMatched
+        Nothing -> Left NotMatched
+    , -- Try and parse @[Text]@. If value is not present then default to empty list.
+      \queryValue -> case eqT :: Maybe (d :~: [Text]) of
+        Just Refl -> case queryValue of
+            Just queryValue -> Right $ Text.splitOn "," (cs queryValue)
+            Nothing -> Right []
+        Nothing -> Left NotMatched
+    , -- Try and parse @[Int]@. If value is not present then default to empty list.
+      \queryValue -> case eqT :: Maybe (d :~: [Int]) of
+        Just Refl -> case queryValue of
+            Just queryValue ->
+                ByteString.split ',' queryValue
+                    |> mapMaybe (\b -> case ByteString.readInt b of Just (n, "") -> Just n; _ -> Nothing)
+                    |> Right
+            Nothing -> Right []
+        Nothing -> Left NotMatched
+    , \queryValue -> case eqT :: Maybe (d :~: [Integer]) of
+        Just Refl -> case queryValue of
+            Just queryValue ->
+                ByteString.split ',' queryValue
+                    |> mapMaybe (\b -> case ByteString.readInteger b of Just (n, "") -> Just n; _ -> Nothing)
+                    |> Right
+            Nothing -> Right []
+        Nothing -> Left NotMatched
+    , -- Try and parse a raw [UUID]
+      \queryValue -> case eqT :: Maybe (d :~: [UUID]) of
+        Just Refl -> case queryValue of
+            Just queryValue ->
+                ByteString.split ',' queryValue
+                    |> mapMaybe fromASCIIBytes
+                    |> Right
+            Nothing -> Right []
+        Nothing -> Left NotMatched
+    , -- Try and parse a raw UUID
+      \queryValue -> case eqT :: Maybe (d :~: UUID) of
+        Just Refl -> case queryValue of
+            Just queryValue ->
+                queryValue
                     |> fromASCIIBytes
                     |> \case
-                        Just uuid -> uuid |> unsafeCoerce |> Right
-                        Nothing -> Left BadType { field = "", value = Just queryValue, expectedType = "UUID" }
-                Nothing -> Left NotMatched
-            ]
+                        Just uuid -> uuid |> Right
+                        Nothing -> Left BadType{field = "", value = Just queryValue, expectedType = "UUID"}
+            Nothing -> Left NotMatched
+        Nothing -> Left NotMatched
+    , -- This has to be last parser in the list
+      --
+      -- Try and parse a UUID wrapped with a Id. In IHP types these are wrapped in a newtype @Id@ such as @Id User@.
+      -- Since @Id@ is a newtype wrapping a UUID, it has the same data representation in GHC.
+      -- Therefore, we're able to safely cast it to its @Id@ type with @unsafeCoerce@.
+      --
+      -- We cannot use 'eqT' here for checking the types, as it's wrapped inside the @Id@ type. We expect
+      -- that if it looks like a UUID, we can just treat it like an @Id@ type. For that to not overshadow other
+      -- parsers, we need to have this last.
+      \queryValue -> case queryValue of
+        Just queryValue ->
+            queryValue
+                |> fromASCIIBytes
+                |> \case
+                    Just uuid -> uuid |> unsafeCoerce |> Right
+                    Nothing -> Left BadType{field = "", value = Just queryValue, expectedType = "UUID"}
+        Nothing -> Left NotMatched
+    ]
 {-# NOINLINE parseFuncs #-}
 
--- | As we fold over a constructor, we want the values parsed from the query string
--- to be in the same order as they are in the constructor.
--- This function uses the field labels from the constructor to sort the values from
--- the query string. As a consequence, constructors with basic record syntax will not work with auto types.
---
--- @data MyController = MyAction Text Int@
---
--- does not work. Instead use,
---
--- @data MyController = MyAction { textArg :: Text, intArg :: Int }@
+{- | As we fold over a constructor, we want the values parsed from the query string
+to be in the same order as they are in the constructor.
+This function uses the field labels from the constructor to sort the values from
+the query string. As a consequence, constructors with basic record syntax will not work with auto types.
+
+@data MyController = MyAction Text Int@
+
+does not work. Instead use,
+
+@data MyController = MyAction { textArg :: Text, intArg :: Int }@
+-}
 querySortedByFields :: Query -> Constr -> Query
-querySortedByFields query constructor = constrFields constructor
+querySortedByFields query constructor =
+    constrFields constructor
         |> map cs
         |> map (\field -> (field, join $ List.lookup field query))
 {-# NOINLINE querySortedByFields #-}
 
--- | Given a constructor and a parsed query string, attempt to construct a value of the constructor's type.
--- For example, given the controller
---
--- @data MyController = MyAction { textArg :: Text, intArg :: Int }@
---
--- this function will receive a representation of the @MyAction@ constructor as well as some query string
--- @[("textArg", "some text"), ("intArg", "123")]@.
---
--- By iterating through the query and attempting to match the type of each constructor argument
--- with some transformation of the query string, we attempt to call @MyAction@.
-applyConstr :: (Data controller, Data idType) => (ByteString -> Maybe idType) -> Constr -> Query -> Either TypedAutoRouteError controller
-applyConstr parseIdType constructor query = let
+{- | Given a constructor and a parsed query string, attempt to construct a value of the constructor's type.
+For example, given the controller
 
-    -- | Given some query item (key, optional value), try to parse into the current expected type
-    -- by iterating through the available parse functions.
-    attemptToParseArg :: forall d. (Data d) => (ByteString, Maybe ByteString) -> [Maybe ByteString -> Either TypedAutoRouteError d] -> State.StateT Query (Either TypedAutoRouteError) d
-    attemptToParseArg queryParam@(queryName, queryValue) [] = State.lift (Left NoConstructorMatched
-                { field = queryName
-                , value = queryValue
-                , expectedType = (dataTypeOf (Prelude.undefined :: d)) |> dataTypeName |> cs
-                })
-    attemptToParseArg queryParam@(k, v) (parseFunc:restFuncs) = case parseFunc v of
+@data MyController = MyAction { textArg :: Text, intArg :: Int }@
+
+this function will receive a representation of the @MyAction@ constructor as well as some query string
+@[("textArg", "some text"), ("intArg", "123")]@.
+
+By iterating through the query and attempting to match the type of each constructor argument
+with some transformation of the query string, we attempt to call @MyAction@.
+-}
+applyConstr :: (Data controller, Data idType) => (ByteString -> Maybe idType) -> Constr -> Query -> Either TypedAutoRouteError controller
+applyConstr parseIdType constructor query =
+    let
+        -- \| Given some query item (key, optional value), try to parse into the current expected type
+        -- by iterating through the available parse functions.
+        attemptToParseArg :: forall d. (Data d) => (ByteString, Maybe ByteString) -> [Maybe ByteString -> Either TypedAutoRouteError d] -> State.StateT Query (Either TypedAutoRouteError) d
+        attemptToParseArg queryParam@(queryName, queryValue) [] =
+            State.lift
+                ( Left
+                    NoConstructorMatched
+                        { field = queryName
+                        , value = queryValue
+                        , expectedType = (dataTypeOf (Prelude.undefined :: d)) |> dataTypeName |> cs
+                        }
+                )
+        attemptToParseArg queryParam@(k, v) (parseFunc : restFuncs) = case parseFunc v of
             Right result -> pure result
             -- BadType will be returned if, for example, a text is passed to a query parameter typed as int.
-            Left badType@BadType{} -> State.lift (Left badType { field = k })
+            Left badType@BadType{} -> State.lift (Left badType{field = k})
             -- otherwise, safe to assume the match just failed, so recurse on the rest of the functions and try to find one that matches.
             Left _ -> attemptToParseArg queryParam restFuncs
 
-    -- | Attempt to parse the current expected type, and return its value.
-    -- For the example @MyController@ this is called twice by @fromConstrM@.
-    -- Once, it is called for @textArg@ where @d :: Text@. Then it is called
-    -- for @intArg@ with @d ::: Int@. With both of these values parsed from the query string,
-    -- the controller action is able to be created.
-    nextField :: forall d. (Data d) => State.StateT Query (Either TypedAutoRouteError) d
-    nextField = do
+        -- \| Attempt to parse the current expected type, and return its value.
+        -- For the example @MyController@ this is called twice by @fromConstrM@.
+        -- Once, it is called for @textArg@ where @d :: Text@. Then it is called
+        -- for @intArg@ with @d ::: Int@. With both of these values parsed from the query string,
+        -- the controller action is able to be created.
+        nextField :: forall d. (Data d) => State.StateT Query (Either TypedAutoRouteError) d
+        nextField = do
             queryParams <- State.get
             case queryParams of
                 [] -> State.lift (Left TooFewArguments)
-                (p@(key, value):rest) -> do
+                (p@(key, value) : rest) -> do
                     State.put rest
                     attemptToParseArg p (parseFuncs parseIdType)
-
-
-   in case State.runStateT (fromConstrM nextField constructor) (querySortedByFields query constructor) of
-        Right (x, []) -> pure x
-        Right (_) -> Left TooFewArguments
-        Left e -> Left e  -- runtime type error
+     in
+        case State.runStateT (fromConstrM nextField constructor) (querySortedByFields query constructor) of
+            Right (x, []) -> pure x
+            Right (_) -> Left TooFewArguments
+            Left e -> Left e -- runtime type error
 {-# NOINLINE applyConstr #-}
 
-class Data controller => AutoRoute controller where
+class (Data controller) => AutoRoute controller where
     autoRouteWithIdType :: (?request :: Request, ?respond :: Respond, Data idType) => (ByteString -> Maybe idType) -> Parser controller
     autoRouteWithIdType parseIdFunc =
         let
             query :: Query
             query = queryString ?request
-        in do
-            -- routeMatchParser is a CAF (no ?request dependency), computed once per controller type.
-            -- It handles the static string matching against URL paths.
-            (constr, allowedMethods) <- routeMatchParser @controller
-            action <- case applyConstr parseIdFunc constr query of
+         in
+            do
+                -- routeMatchParser is a CAF (no ?request dependency), computed once per controller type.
+                -- It handles the static string matching against URL paths.
+                (constr, allowedMethods) <- routeMatchParser @controller
+                action <- case applyConstr parseIdFunc constr query of
                     Right parsedAction -> pure parsedAction
                     Left e -> Exception.throw e
-            method <- getMethod
-            unless (allowedMethods |> includes method) (Exception.throw UnexpectedMethodException { allowedMethods, method })
-            pure action
-    {-# INLINABLE autoRouteWithIdType #-}
+                method <- getMethod
+                unless (allowedMethods |> includes method) (Exception.throw UnexpectedMethodException{allowedMethods, method})
+                pure action
+    {-# INLINEABLE autoRouteWithIdType #-}
 
     autoRoute :: (?request :: Request, ?respond :: Respond) => Parser controller
     autoRoute = autoRouteWithIdType (\_ -> Nothing :: Maybe Integer)
-    {-# INLINABLE autoRoute #-}
+    {-# INLINEABLE autoRoute #-}
 
-    -- | Constructs a controller value from a matched constructor and query string.
-    --
-    -- Uses the same id parser as 'autoRoute'. Override this when you override
-    -- 'autoRoute' with 'autoRouteWithIdType' to keep them in sync.
-    --
-    -- This is used by 'parseRoute' to defer query string parsing to the Application
-    -- closure while keeping path matching in the parser.
-    --
-    -- __Example:__
-    --
-    -- > instance AutoRoute MyController where
-    -- >     autoRoute = autoRouteWithIdType (parseIntegerId @(Id MyModel))
-    -- >     applyAction = applyConstr (parseIntegerId @(Id MyModel))
+    {- | Constructs a controller value from a matched constructor and query string.
+
+    Uses the same id parser as 'autoRoute'. Override this when you override
+    'autoRoute' with 'autoRouteWithIdType' to keep them in sync.
+
+    This is used by 'parseRoute' to defer query string parsing to the Application
+    closure while keeping path matching in the parser.
+
+    __Example:__
+
+    > instance AutoRoute MyController where
+    >     autoRoute = autoRouteWithIdType (parseIntegerId @(Id MyModel))
+    >     applyAction = applyConstr (parseIntegerId @(Id MyModel))
+    -}
     applyAction :: Constr -> Query -> Either TypedAutoRouteError controller
     applyAction = applyConstr (\_ -> Nothing :: Maybe Integer)
     {-# INLINE applyAction #-}
 
-    -- | Specifies the allowed HTTP methods for a given action
-    --
-    -- The default implementation does a smart guess based on the
-    -- usual naming conventions for controllers.
-    --
-    -- __Example (for default implementation):__
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "DeleteProjectAction"
-    -- [DELETE]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "UpdateProjectAction"
-    -- [POST, PATCH]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "CreateProjectAction"
-    -- [POST]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "ShowProjectAction"
-    -- [GET, HEAD]
-    --
-    -- >>> allowedMethodsForAction @ProjectsController "HelloAction"
-    -- [GET, POST, HEAD]
-    --
+    {- | Specifies the allowed HTTP methods for a given action
+
+    The default implementation does a smart guess based on the
+    usual naming conventions for controllers.
+
+    __Example (for default implementation):__
+
+    >>> allowedMethodsForAction @ProjectsController "DeleteProjectAction"
+    [DELETE]
+
+    >>> allowedMethodsForAction @ProjectsController "UpdateProjectAction"
+    [POST, PATCH]
+
+    >>> allowedMethodsForAction @ProjectsController "CreateProjectAction"
+    [POST]
+
+    >>> allowedMethodsForAction @ProjectsController "ShowProjectAction"
+    [GET, HEAD]
+
+    >>> allowedMethodsForAction @ProjectsController "HelloAction"
+    [GET, POST, HEAD]
+    -}
     allowedMethodsForAction :: ByteString -> [StdMethod]
     allowedMethodsForAction actionName =
-            case actionName of
-                a | "Delete" `ByteString.isPrefixOf` a -> [DELETE]
-                a | "Update" `ByteString.isPrefixOf` a -> [POST, PATCH]
-                a | "Create" `ByteString.isPrefixOf` a -> [POST]
-                a | "Show"   `ByteString.isPrefixOf` a -> [GET, HEAD]
-                _ -> [GET, POST, HEAD]
+        case actionName of
+            a | "Delete" `ByteString.isPrefixOf` a -> [DELETE]
+            a | "Update" `ByteString.isPrefixOf` a -> [POST, PATCH]
+            a | "Create" `ByteString.isPrefixOf` a -> [POST]
+            a | "Show" `ByteString.isPrefixOf` a -> [GET, HEAD]
+            _ -> [GET, POST, HEAD]
     {-# INLINE allowedMethodsForAction #-}
 
-    -- | Custom route parser for overriding individual action routes.
-    --
-    -- Use this to provide custom URL patterns for specific actions while keeping
-    -- the auto-generated routes for all other actions.
-    --
-    -- The custom routes are tried first, before the auto-generated routes.
-    -- The auto-generated route for the overridden action still works as a fallback.
-    --
-    -- __Example:__
-    --
-    -- > instance AutoRoute PostsController where
-    -- >     customRoutes = do
-    -- >         string "/posts/"
-    -- >         postId <- parseId
-    -- >         endOfInput
-    -- >         onlyAllowMethods [GET, HEAD]
-    -- >         pure ShowPostAction { postId }
-    --
+    {- | Custom route parser for overriding individual action routes.
+
+    Use this to provide custom URL patterns for specific actions while keeping
+    the auto-generated routes for all other actions.
+
+    The custom routes are tried first, before the auto-generated routes.
+    The auto-generated route for the overridden action still works as a fallback.
+
+    __Example:__
+
+    > instance AutoRoute PostsController where
+    >     customRoutes = do
+    >         string "/posts/"
+    >         postId <- parseId
+    >         endOfInput
+    >         onlyAllowMethods [GET, HEAD]
+    >         pure ShowPostAction { postId }
+    -}
     customRoutes :: (?request :: Request, ?respond :: Respond) => Parser controller
     customRoutes = empty
     {-# INLINE customRoutes #-}
 
-    -- | Custom path generation for overriding individual action URLs.
-    --
-    -- Use this together with 'customRoutes' to generate custom URLs for specific
-    -- actions while keeping the auto-generated URLs for all other actions.
-    --
-    -- Return @Just path@ for actions with custom URLs, or @Nothing@ to fall back
-    -- to the auto-generated URL.
-    --
-    -- __Example:__
-    --
-    -- > instance AutoRoute PostsController where
-    -- >     customPathTo ShowPostAction { postId } = Just ("/posts/" <> tshow postId)
-    -- >     customPathTo _ = Nothing
-    --
+    {- | Custom path generation for overriding individual action URLs.
+
+    Use this together with 'customRoutes' to generate custom URLs for specific
+    actions while keeping the auto-generated URLs for all other actions.
+
+    Return @Just path@ for actions with custom URLs, or @Nothing@ to fall back
+    to the auto-generated URL.
+
+    __Example:__
+
+    > instance AutoRoute PostsController where
+    >     customPathTo ShowPostAction { postId } = Just ("/posts/" <> tshow postId)
+    >     customPathTo _ = Nothing
+    -}
     customPathTo :: controller -> Maybe Text
     customPathTo _ = Nothing
     {-# INLINE customPathTo #-}
 
--- | Static route-matching parser that becomes a CAF when specialized for a concrete
--- controller type. Uses a 'HashMap' for O(1) action name lookup after matching the prefix.
--- Since it doesn't reference @?request@ or @?respond@, GHC can float this out as a
--- top-level constant.
+{- | Static route-matching parser that becomes a CAF when specialized for a concrete
+controller type. Uses a 'HashMap' for O(1) action name lookup after matching the prefix.
+Since it doesn't reference @?request@ or @?respond@, GHC can float this out as a
+top-level constant.
+-}
 routeMatchParser :: forall controller. (Data controller, AutoRoute controller) => Parser (Constr, [StdMethod])
 routeMatchParser = do
     string prefix
@@ -733,12 +805,13 @@ routeMatchParser = do
     case HashMap.lookup remaining actionMatchMap of
         Just result -> pure result
         Nothing -> fail "no matching action"
-    where
-        prefix :: ByteString
-        prefix = Text.encodeUtf8 (actionPrefixText @controller)
+  where
+    prefix :: ByteString
+    prefix = Text.encodeUtf8 (actionPrefixText @controller)
 
-        actionMatchMap :: HashMap.HashMap ByteString (Constr, [StdMethod])
-        actionMatchMap = HashMap.fromList
+    actionMatchMap :: HashMap.HashMap ByteString (Constr, [StdMethod])
+    actionMatchMap =
+        HashMap.fromList
             [ (actionPath, (constr, allowedMethods))
             | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
             , let actionName = ByteString.pack (showConstr constr)
@@ -747,141 +820,165 @@ routeMatchParser = do
             ]
 {-# NOINLINE routeMatchParser #-}
 
--- | Returns the url prefix for a controller. The prefix is based on the
--- module where the controller is defined.
---
--- All controllers defined in the `Web/` directory don't have a prefix at all.
---
--- E.g. controllers in the `Admin/` directory are prefixed with @/admin/@.
-actionPrefixText :: forall (controller :: Type). Typeable controller => Text
+{- | Returns the url prefix for a controller. The prefix is based on the
+module where the controller is defined.
+
+All controllers defined in the `Web/` directory don't have a prefix at all.
+
+E.g. controllers in the `Admin/` directory are prefixed with @/admin/@.
+-}
+actionPrefixText :: forall (controller :: Type). (Typeable controller) => Text
 actionPrefixText
     | "Web." `Text.isPrefixOf` moduleName = "/"
     | "IHP." `Text.isPrefixOf` moduleName = "/"
     | Text.null moduleName = "/"
     | otherwise = "/" <> Text.toLower (getPrefix moduleName) <> "/"
-    where
-        moduleName :: Text
-        moduleName = Text.pack $ Typeable.typeOf (error "unreachable" :: controller)
+  where
+    moduleName :: Text
+    moduleName =
+        Text.pack $
+            Typeable.typeOf (error "unreachable" :: controller)
                 |> Typeable.typeRepTyCon
                 |> Typeable.tyConModule
 
-        getPrefix :: Text -> Text
-        getPrefix t = fst (Text.breakOn "." t)
+    getPrefix :: Text -> Text
+    getPrefix t = fst (Text.breakOn "." t)
 {-# NOINLINE actionPrefixText #-}
 
--- | Strips the "Action" suffix from action names
---
--- >>> stripActionSuffixByteString "ShowUserAction"
--- "ShowUser"
---
--- >>> stripActionSuffixByteString "UsersAction"
--- "UsersAction"
---
--- >>> stripActionSuffixByteString "User"
--- "User"
+{- | Strips the "Action" suffix from action names
+
+>>> stripActionSuffixByteString "ShowUserAction"
+"ShowUser"
+
+>>> stripActionSuffixByteString "UsersAction"
+"UsersAction"
+
+>>> stripActionSuffixByteString "User"
+"User"
+-}
 stripActionSuffixByteString :: ByteString -> ByteString
 stripActionSuffixByteString actionName = fromMaybe actionName (ByteString.stripSuffix "Action" actionName)
 {-# INLINE stripActionSuffixByteString #-}
 
--- | Strips the "Action" suffix from action names
---
--- >>> stripActionSuffixText "ShowUserAction"
--- "ShowUser"
---
--- >>> stripActionSuffixText "UsersAction"
--- "UsersAction"
---
--- >>> stripActionSuffixText "User"
--- "User"
+{- | Strips the "Action" suffix from action names
+
+>>> stripActionSuffixText "ShowUserAction"
+"ShowUser"
+
+>>> stripActionSuffixText "UsersAction"
+"UsersAction"
+
+>>> stripActionSuffixText "User"
+"User"
+-}
 stripActionSuffixText :: Text -> Text
 stripActionSuffixText actionName = fromMaybe actionName (Text.stripSuffix "Action" actionName)
 {-# INLINE stripActionSuffixText #-}
 
-
--- | Returns the create action for a given controller.
--- Example: `createAction @UsersController == Just CreateUserAction`
-createAction :: forall controller. AutoRoute controller => Maybe controller
+{- | Returns the create action for a given controller.
+Example: `createAction @UsersController == Just CreateUserAction`
+-}
+createAction :: forall controller. (AutoRoute controller) => Maybe controller
 createAction = fmap fromConstr createConstructor
-    where
-        createConstructor :: Maybe Constr
-        createConstructor = find isCreateConstructor allConstructors
+  where
+    createConstructor :: Maybe Constr
+    createConstructor = find isCreateConstructor allConstructors
 
-        allConstructors :: [Constr]
-        allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+    allConstructors :: [Constr]
+    allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
 
-        isCreateConstructor :: Constr -> Bool
-        isCreateConstructor constructor = "Create" `isPrefixOf` showConstr constructor && Prelude.null (constrFields constructor)
+    isCreateConstructor :: Constr -> Bool
+    isCreateConstructor constructor = "Create" `isPrefixOf` showConstr constructor && Prelude.null (constrFields constructor)
 {-# INLINE createAction #-}
 
--- | Returns the update action when given a controller and id.
--- Example: `updateAction @UsersController == Just (\id -> UpdateUserAction id)`
-updateAction :: forall controller id. AutoRoute controller => Maybe (id -> controller)
+{- | Returns the update action when given a controller and id.
+Example: `updateAction @UsersController == Just (\id -> UpdateUserAction id)`
+-}
+updateAction :: forall controller id. (AutoRoute controller) => Maybe (id -> controller)
 updateAction =
-        case updateConstructor of
-            Just constructor -> Just $ \id -> buildInstance constructor id
-            Nothing -> Nothing
-    where
-        updateConstructor :: Maybe Constr
-        updateConstructor = find isUpdateConstructor allConstructors
+    case updateConstructor of
+        Just constructor -> Just $ \id -> buildInstance constructor id
+        Nothing -> Nothing
+  where
+    updateConstructor :: Maybe Constr
+    updateConstructor = find isUpdateConstructor allConstructors
 
-        buildInstance :: Constr -> id -> controller
-        buildInstance constructor id = State.evalState ((fromConstrM (do
-                i <- State.get
+    buildInstance :: Constr -> id -> controller
+    buildInstance constructor id =
+        State.evalState
+            ( ( fromConstrM
+                    ( do
+                        i <- State.get
 
-                State.modify (+1)
-                pure (unsafeCoerce id)
-            )) constructor) 0
+                        State.modify (+ 1)
+                        pure (unsafeCoerce id)
+                    )
+              )
+                constructor
+            )
+            0
 
-        allConstructors :: [Constr]
-        allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+    allConstructors :: [Constr]
+    allConstructors = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
 
-        isUpdateConstructor :: Constr -> Bool
-        isUpdateConstructor constructor = "Update" `isPrefixOf` (showConstr constructor) && (length (constrFields constructor) == 1)
+    isUpdateConstructor :: Constr -> Bool
+    isUpdateConstructor constructor = "Update" `isPrefixOf` (showConstr constructor) && (length (constrFields constructor) == 1)
 {-# INLINE updateAction #-}
 
 instance {-# OVERLAPPABLE #-} (AutoRoute controller, Controller controller) => CanRoute controller where
     parseRoute' = customRoutes <|> autoRoute
-    {-# INLINABLE parseRoute' #-}
+    {-# INLINEABLE parseRoute' #-}
 
-    -- | This is only used as a fallback parser (via lazy thunk in 'ControllerRouteMap').
+    -- \| This is only used as a fallback parser (via lazy thunk in 'ControllerRouteMap').
     -- The primary routing path goes through 'findInRouteMaps' / 'buildAutoRouteMap' instead.
     -- Performance here doesn't matter — keep it simple.
-    parseRouteWithAction toApp = (do
-        action <- customRoutes @controller
-        pure (toApp action)
-      ) <|> (do
-        (constr, allowedMethods) <- routeMatchParser @controller
-        pure $ \waiRequest waiRespond -> wrapRouterException do
-            case applyAction @controller constr (queryString waiRequest) of
-                Left e -> Exception.throw e
-                Right action -> do
-                    case parseMethod (requestMethod waiRequest) of
-                        Right method -> do
-                            unless (allowedMethods |> includes method)
-                                (Exception.throw UnexpectedMethodException { allowedMethods, method })
-                            toApp action waiRequest waiRespond
-                        Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
-      )
-    {-# INLINABLE parseRouteWithAction #-}
+    parseRouteWithAction toApp =
+        ( do
+            action <- customRoutes @controller
+            pure (toApp action)
+        )
+            <|> ( do
+                    (constr, allowedMethods) <- routeMatchParser @controller
+                    pure $ \waiRequest waiRespond -> wrapRouterException do
+                        case applyAction @controller constr (queryString waiRequest) of
+                            Left e -> Exception.throw e
+                            Right action -> do
+                                case parseMethod (requestMethod waiRequest) of
+                                    Right method -> do
+                                        unless
+                                            (allowedMethods |> includes method)
+                                            (Exception.throw UnexpectedMethodException{allowedMethods, method})
+                                        toApp action waiRequest waiRespond
+                                    Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
+                )
+    {-# INLINEABLE parseRouteWithAction #-}
 
-    -- | Override to use 'ControllerRouteMap' for O(1) HashMap dispatch.
-    toControllerRoute :: forall application.
-        ( ?request :: Request, ?respond :: Respond, Controller controller
-        , InitControllerContext application, ?application :: application
-        , Typeable application, Typeable controller
-        ) => ControllerRoute application
-    toControllerRoute = ControllerRouteMap
-        { routeMap = buildAutoRouteMap @controller @application
-        , routeParser = parseRouteWithAction @controller (runAction' @application)
-        , routeInspection = RouteLeaf UndocumentedRoute
-        }
-    {-# INLINABLE toControllerRoute #-}
+    -- \| Override to use 'ControllerRouteMap' for O(1) HashMap dispatch.
+    toControllerRoute ::
+        forall application.
+        ( ?request :: Request
+        , ?respond :: Respond
+        , Controller controller
+        , InitControllerContext application
+        , ?application :: application
+        , Typeable application
+        , Typeable controller
+        ) =>
+        ControllerRoute application
+    toControllerRoute =
+        ControllerRouteMap
+            { routeMap = buildAutoRouteMap @controller @application
+            , routeParser = parseRouteWithAction @controller (runAction' @application)
+            , routeInspection = RouteLeaf UndocumentedRoute
+            }
+    {-# INLINEABLE toControllerRoute #-}
 
--- | Instances of the @QueryParam@ type class can be represented in URLs as query parameters.
--- Currently this is only Int, Text, and both wrapped in List and Maybe.
--- IDs also are representable in a URL, but we are unable to match on polymorphic types using reflection,
--- so we fall back to the default "show" for these.
-class Data a => QueryParam a where
+{- | Instances of the @QueryParam@ type class can be represented in URLs as query parameters.
+Currently this is only Int, Text, and both wrapped in List and Maybe.
+IDs also are representable in a URL, but we are unable to match on polymorphic types using reflection,
+so we fall back to the default "show" for these.
+-}
+class (Data a) => QueryParam a where
     showQueryParam :: a -> String
 
 instance QueryParam Text where
@@ -896,11 +993,11 @@ instance QueryParam Integer where
 instance QueryParam UUID where
     showQueryParam = show
 
-instance QueryParam a => QueryParam (Maybe a) where
+instance (QueryParam a) => QueryParam (Maybe a) where
     showQueryParam (Just val) = showQueryParam val
     showQueryParam Nothing = ""
 
-instance QueryParam a => QueryParam [a] where
+instance (QueryParam a) => QueryParam [a] where
     showQueryParam = List.intercalate "," . map showQueryParam
 
 instance {-# OVERLAPPABLE #-} (Show controller, AutoRoute controller) => HasPath controller where
@@ -910,39 +1007,40 @@ instance {-# OVERLAPPABLE #-} (Show controller, AutoRoute controller) => HasPath
         Nothing ->
             let !ci = constrIndex (toConstr action) - 1
                 (!basePath, !fieldNames) = constrInfoCache !! ci
-            in case fieldNames of
-                [] -> basePath
-                _ ->
-                    let !fieldValues = gmapQ renderFieldForUrl action
-                    in basePath <> buildQueryText fieldNames fieldValues
-        where
-            -- Precomputed per constructor: (basePath, fieldNames).
-            -- Does not reference 'action', so GHC floats this out as a CAF
-            -- when the instance is specialized for a concrete controller type.
-            constrInfoCache :: [(Text, [Text])]
-            constrInfoCache = map mkInfo allConstrs
-                where
-                    allConstrs = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-                    !appPrefix = actionPrefixText @controller
-                    mkInfo c =
-                        let !bp = appPrefix <> stripActionSuffixText (Text.pack (showConstr c))
-                            !fns = map Text.pack (constrFields c)
-                        in (bp, fns)
+             in case fieldNames of
+                    [] -> basePath
+                    _ ->
+                        let !fieldValues = gmapQ renderFieldForUrl action
+                         in basePath <> buildQueryText fieldNames fieldValues
+      where
+        -- Precomputed per constructor: (basePath, fieldNames).
+        -- Does not reference 'action', so GHC floats this out as a CAF
+        -- when the instance is specialized for a concrete controller type.
+        constrInfoCache :: [(Text, [Text])]
+        constrInfoCache = map mkInfo allConstrs
+          where
+            allConstrs = dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+            !appPrefix = actionPrefixText @controller
+            mkInfo c =
+                let !bp = appPrefix <> stripActionSuffixText (Text.pack (showConstr c))
+                    !fns = map Text.pack (constrFields c)
+                 in (bp, fns)
 
-            buildQueryText :: [Text] -> [Text] -> Text
-            buildQueryText names values =
-                zip names values
+        buildQueryText :: [Text] -> [Text] -> Text
+        buildQueryText names values =
+            zip names values
                 |> filter (\(_, v) -> not (Text.null v))
                 |> map (\(k, v) -> k <> "=" <> URI.encodeText v)
                 |> Text.intercalate "&"
                 |> (\q -> if Text.null q then q else Text.cons '?' q)
 
--- | Render a controller field value as 'Text' for URL query parameter inclusion.
---
--- Uses type reflection ('eqT') to match known types (Text, UUID, Int, Integer,
--- and their Maybe\/List variants). For newtypes like @Id'@ that wrap a known type,
--- falls back to recursive unwrap via 'gmapQ'.
-renderFieldForUrl :: forall d. Data d => d -> Text
+{- | Render a controller field value as 'Text' for URL query parameter inclusion.
+
+Uses type reflection ('eqT') to match known types (Text, UUID, Int, Integer,
+and their Maybe\/List variants). For newtypes like @Id'@ that wrap a known type,
+falls back to recursive unwrap via 'gmapQ'.
+-}
+renderFieldForUrl :: forall d. (Data d) => d -> Text
 renderFieldForUrl val
     -- UUID first: most common type after Id newtype unwrap
     | Just Refl <- eqT @d @UUID = toText val
@@ -970,187 +1068,203 @@ getMethod =
     case parseMethod ?request.requestMethod of
         Left error -> fail (ByteString.unpack error)
         Right method -> pure method
-{-# INLINABLE getMethod #-}
+{-# INLINEABLE getMethod #-}
 
--- | Routes a given path to an action when requested via GET.
---
--- __Example:__
---
--- > instance FrontController WebApplication where
--- >     controllers = [
--- >             get "/my-custom-page" NewSessionAction
--- >         ]
---
--- The request @GET \/my-custom-page@ is now executing NewSessionAction
---
--- Also see 'post'.
-get :: (Controller action
+{- | Routes a given path to an action when requested via GET.
+
+__Example:__
+
+> instance FrontController WebApplication where
+>     controllers = [
+>             get "/my-custom-page" NewSessionAction
+>         ]
+
+The request @GET \/my-custom-page@ is now executing NewSessionAction
+
+Also see 'post'.
+-}
+get ::
+    ( Controller action
     , InitControllerContext application
     , ?application :: application
     , Typeable application
     , Typeable action
-    ) => ByteString -> action -> ControllerRoute application
+    ) =>
+    ByteString -> action -> ControllerRoute application
 get path action = rawRoute do
     string path
     pure $ \waiRequest waiRespond ->
         case parseMethod (requestMethod waiRequest) of
             Right GET -> runAction' action waiRequest waiRespond
             Right HEAD -> runAction' action waiRequest waiRespond
-            Right method -> Exception.throw UnexpectedMethodException { allowedMethods = [GET, HEAD], method }
+            Right method -> Exception.throw UnexpectedMethodException{allowedMethods = [GET, HEAD], method}
             Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
-{-# INLINABLE get #-}
+{-# INLINEABLE get #-}
 
--- | Routes a given path to an action when requested via POST.
---
--- __Example:__
---
--- > instance FrontController WebApplication where
--- >     controllers = [
--- >             post "/do-something" DoSomethingAction
--- >         ]
---
--- The request @POST \/do-something@ is now executing DoSomethingAction
---
--- Also see 'get'.
-post :: (Controller action
+{- | Routes a given path to an action when requested via POST.
+
+__Example:__
+
+> instance FrontController WebApplication where
+>     controllers = [
+>             post "/do-something" DoSomethingAction
+>         ]
+
+The request @POST \/do-something@ is now executing DoSomethingAction
+
+Also see 'get'.
+-}
+post ::
+    ( Controller action
     , InitControllerContext application
     , ?application :: application
     , Typeable application
     , Typeable action
-    ) => ByteString -> action -> ControllerRoute application
+    ) =>
+    ByteString -> action -> ControllerRoute application
 post path action = rawRoute do
     string path
     pure $ \waiRequest waiRespond ->
         case parseMethod (requestMethod waiRequest) of
             Right POST -> runAction' action waiRequest waiRespond
-            Right method -> Exception.throw UnexpectedMethodException { allowedMethods = [POST], method }
+            Right method -> Exception.throw UnexpectedMethodException{allowedMethods = [POST], method}
             Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
-{-# INLINABLE post #-}
+{-# INLINEABLE post #-}
 
--- | Filter methods when writing a custom routing parser
---
--- __Example:__
---
--- > instance CanRoute ApiController where
--- >    parseRoute' = do
--- >        string "/api/"
--- >        let
--- >            createRecordAction = do
--- >                onlyAllowMethods [POST]
--- >
--- >                table <- parseText
--- >                endOfInput
--- >                pure CreateRecordAction { table }
--- >
--- >            updateRecordAction = do
--- >                onlyAllowMethods [PATCH]
--- >
--- >                table <- parseText
--- >                string "/"
--- >                id <- parseUUID
--- >                pure UpdateRecordAction { table, id }
--- >
--- > createRecordAction <|> updateRecordAction
---
+{- | Filter methods when writing a custom routing parser
+
+__Example:__
+
+> instance CanRoute ApiController where
+>    parseRoute' = do
+>        string "/api/"
+>        let
+>            createRecordAction = do
+>                onlyAllowMethods [POST]
+>
+>                table <- parseText
+>                endOfInput
+>                pure CreateRecordAction { table }
+>
+>            updateRecordAction = do
+>                onlyAllowMethods [PATCH]
+>
+>                table <- parseText
+>                string "/"
+>                id <- parseUUID
+>                pure UpdateRecordAction { table, id }
+>
+> createRecordAction <|> updateRecordAction
+-}
 onlyAllowMethods :: (?request :: Request, ?respond :: Respond) => [StdMethod] -> Parser ()
 onlyAllowMethods methods = do
     method <- getMethod
     unless (method `elem` methods) (fail ("Invalid method, expected one of: " <> show methods))
-{-# INLINABLE onlyAllowMethods #-}
+{-# INLINEABLE onlyAllowMethods #-}
 
--- | Routes to a given WebSocket app if the path matches the WebSocket app name
---
--- __Example:__
---
--- > instance FrontController WebApplication where
--- >     controllers = [
--- >             webSocketApp @AutoRefreshWSApp
--- >         ]
---
--- The request @\/AutoRefreshWSApp@ will call the AutoRefreshWSApp
---
-webSocketApp :: forall webSocketApp application.
+{- | Routes to a given WebSocket app if the path matches the WebSocket app name
+
+__Example:__
+
+> instance FrontController WebApplication where
+>     controllers = [
+>             webSocketApp @AutoRefreshWSApp
+>         ]
+
+The request @\/AutoRefreshWSApp@ will call the AutoRefreshWSApp
+-}
+webSocketApp ::
+    forall webSocketApp application.
     ( WSApp webSocketApp
     , InitControllerContext application
     , ?application :: application
     , Typeable application
     , Typeable webSocketApp
-    ) => ControllerRoute application
+    ) =>
+    ControllerRoute application
 webSocketApp = webSocketAppWithCustomPath @webSocketApp typeName
-    where
-        typeName :: ByteString
-        typeName = Typeable.typeOf (error "unreachable" :: webSocketApp)
-                |> show
-                |> ByteString.pack
-{-# INLINABLE webSocketApp #-}
+  where
+    typeName :: ByteString
+    typeName =
+        Typeable.typeOf (error "unreachable" :: webSocketApp)
+            |> show
+            |> ByteString.pack
+{-# INLINEABLE webSocketApp #-}
 
-webSocketAppWithHTTPFallback :: forall webSocketApp application.
+webSocketAppWithHTTPFallback ::
+    forall webSocketApp application.
     ( WSApp webSocketApp
     , InitControllerContext application
     , ?application :: application
     , Typeable application
     , Typeable webSocketApp
     , Controller webSocketApp
-    ) => ControllerRoute application
+    ) =>
+    ControllerRoute application
 webSocketAppWithHTTPFallback = webSocketAppWithCustomPathAndHTTPFallback @webSocketApp @application typeName
-    where
-        typeName :: ByteString
-        typeName = Typeable.typeOf (error "unreachable" :: webSocketApp)
-                |> show
-                |> ByteString.pack
-{-# INLINABLE webSocketAppWithHTTPFallback #-}
+  where
+    typeName :: ByteString
+    typeName =
+        Typeable.typeOf (error "unreachable" :: webSocketApp)
+            |> show
+            |> ByteString.pack
+{-# INLINEABLE webSocketAppWithHTTPFallback #-}
 
--- | Routes to a given WebSocket app if the path matches
---
--- __Example:__
---
--- > instance FrontController WebApplication where
--- >     controllers = [
--- >             webSocketAppWithCustomPath @AutoRefreshWSApp "my-ws-app"
--- >         ]
---
--- The request @\/my-ws-app@ will call the AutoRefreshWSApp
---
-webSocketAppWithCustomPath :: forall webSocketApp application.
+{- | Routes to a given WebSocket app if the path matches
+
+__Example:__
+
+> instance FrontController WebApplication where
+>     controllers = [
+>             webSocketAppWithCustomPath @AutoRefreshWSApp "my-ws-app"
+>         ]
+
+The request @\/my-ws-app@ will call the AutoRefreshWSApp
+-}
+webSocketAppWithCustomPath ::
+    forall webSocketApp application.
     ( WSApp webSocketApp
     , InitControllerContext application
     , ?application :: application
     , Typeable application
     , Typeable webSocketApp
-    ) => ByteString -> ControllerRoute application
+    ) =>
+    ByteString -> ControllerRoute application
 webSocketAppWithCustomPath path = rawRoute do
-        Attoparsec.char '/'
-        string path
-        pure $ withImplicits (startWebSocketAppAndFailOnHTTP @webSocketApp @application (WS.initialState @webSocketApp))
-{-# INLINABLE webSocketAppWithCustomPath #-}
+    Attoparsec.char '/'
+    string path
+    pure $ withImplicits (startWebSocketAppAndFailOnHTTP @webSocketApp @application (WS.initialState @webSocketApp))
+{-# INLINEABLE webSocketAppWithCustomPath #-}
 
-webSocketAppWithCustomPathAndHTTPFallback :: forall webSocketApp application.
+webSocketAppWithCustomPathAndHTTPFallback ::
+    forall webSocketApp application.
     ( WSApp webSocketApp
     , InitControllerContext application
     , ?application :: application
     , Typeable application
     , Typeable webSocketApp
     , Controller webSocketApp
-    ) => ByteString -> ControllerRoute application
+    ) =>
+    ByteString -> ControllerRoute application
 webSocketAppWithCustomPathAndHTTPFallback path = rawRoute do
-        Attoparsec.char '/'
-        string path
-        let action = WS.initialState @webSocketApp
-        pure $ withImplicits (startWebSocketApp @webSocketApp @application action (runActionWithNewContext action))
-{-# INLINABLE webSocketAppWithCustomPathAndHTTPFallback #-}
-
+    Attoparsec.char '/'
+    string path
+    let action = WS.initialState @webSocketApp
+    pure $ withImplicits (startWebSocketApp @webSocketApp @application action (runActionWithNewContext action))
+{-# INLINEABLE webSocketAppWithCustomPathAndHTTPFallback #-}
 
 -- | Defines the start page for a router (when @\/@ is requested).
-startPage :: forall action application. (Controller action, InitControllerContext application, ?application::application, Typeable application, Typeable action) => action -> ControllerRoute application
+startPage :: forall action application. (Controller action, InitControllerContext application, ?application :: application, Typeable application, Typeable action) => action -> ControllerRoute application
 startPage action = get (Text.encodeUtf8 (actionPrefixText @action)) action
-{-# INLINABLE startPage #-}
+{-# INLINEABLE startPage #-}
 
 withPrefix :: ByteString -> [ControllerRoute application] -> ControllerRoute application
-withPrefix prefix routes = ControllerRouteParser
-    { routeParser = string prefix >> choice (map (\route -> compileControllerRoute route <* endOfInput) routes)
-    , routeInspection = RoutePrefix prefix (map routeInspection routes)
-    }
-{-# INLINABLE withPrefix #-}
+withPrefix prefix routes =
+    ControllerRouteParser
+        { routeParser = string prefix >> choice (map (\route -> compileControllerRoute route <* endOfInput) routes)
+        , routeInspection = RoutePrefix prefix (map routeInspection routes)
+        }
+{-# INLINEABLE withPrefix #-}
 
 frontControllerToWAIApp :: forall app (autoRefreshApp :: Type). (FrontController app, WSApp autoRefreshApp, Typeable autoRefreshApp, InitControllerContext ()) => Middleware -> app -> Application -> Application
 frontControllerToWAIApp middleware application notFoundAction waiRequest waiRespond = do
@@ -1159,16 +1273,19 @@ frontControllerToWAIApp middleware application notFoundAction waiRequest waiResp
 
     let autoRefreshWSParser :: Parser Application
         autoRefreshWSParser =
-            let ?application = () in
-            let typeName = Typeable.typeOf (error "unreachable" :: autoRefreshApp)
-                    |> show |> ByteString.pack
-            in do
-                Attoparsec.char '/'
-                string typeName
-                pure $ withImplicits (startWebSocketAppAndFailOnHTTP @autoRefreshApp @() (WS.initialState @autoRefreshApp))
+            let ?application = ()
+             in let typeName =
+                        Typeable.typeOf (error "unreachable" :: autoRefreshApp)
+                            |> show
+                            |> ByteString.pack
+                 in do
+                        Attoparsec.char '/'
+                        string typeName
+                        pure $ withImplicits (startWebSocketAppAndFailOnHTTP @autoRefreshApp @() (WS.initialState @autoRefreshApp))
 
-    let allRoutes = let ?application = application in
-            ControllerRouteParser { routeParser = autoRefreshWSParser, routeInspection = RouteLeaf UndocumentedRoute } : controllers @app
+    let allRoutes =
+            let ?application = application
+             in ControllerRouteParser{routeParser = autoRefreshWSParser, routeInspection = RouteLeaf UndocumentedRoute} : controllers @app
 
     let path = waiRequest.rawPathInfo
 
@@ -1182,28 +1299,29 @@ frontControllerToWAIApp middleware application notFoundAction waiRequest waiResp
             let customParsers = concatMap getRouteParsers allRoutes
 
             routedAction :: Either String Application <-
-                (do
+                ( do
                     res <- evaluate $ parseOnly (choice (map (<* endOfInput) customParsers)) path
                     case res of
                         Left s -> pure $ Left s
                         Right action -> pure $ Right action
-                    )
-                |> wrapRouterException
+                )
+                    |> wrapRouterException
             case routedAction of
                 Left _ -> notFoundAction waiRequest waiRespond
                 Right action -> (middleware action) waiRequest waiRespond
-{-# INLINABLE frontControllerToWAIApp #-}
+{-# INLINEABLE frontControllerToWAIApp #-}
 
 mountFrontController :: forall frontController application. (?request :: Request, ?respond :: Respond, FrontController frontController) => frontController -> ControllerRoute application
 mountFrontController application =
     let ?application = application
-    in ControllerRouteParser
-        { routeParser = router []
-        , routeInspection = RouteCollection (controllers @frontController |> map routeInspection)
-        }
-{-# INLINABLE mountFrontController #-}
+     in ControllerRouteParser
+            { routeParser = router []
+            , routeInspection = RouteCollection (controllers @frontController |> map routeInspection)
+            }
+{-# INLINEABLE mountFrontController #-}
 
-buildDocumentedRoute :: forall controller application.
+buildDocumentedRoute ::
+    forall controller application.
     ( ?request :: Request
     , ?respond :: Respond
     , Controller controller
@@ -1213,15 +1331,18 @@ buildDocumentedRoute :: forall controller application.
     , ?application :: application
     , Typeable application
     , Typeable controller
-    ) => RouteDocumentation -> ControllerRoute application
-buildDocumentedRoute routeDocumentation = ControllerRouteMap
-    { routeMap = buildAutoRouteMapWithDocumentation @controller @application routeDocumentation
-    , routeParser = parseRouteWithAction @controller (runActionWithRouteDocumentation @application routeDocumentation)
-    , routeInspection = RouteLeaf routeDocumentation
-    }
-{-# INLINABLE buildDocumentedRoute #-}
+    ) =>
+    RouteDocumentation -> ControllerRoute application
+buildDocumentedRoute routeDocumentation =
+    ControllerRouteMap
+        { routeMap = buildAutoRouteMapWithDocumentation @controller @application routeDocumentation
+        , routeParser = parseRouteWithAction @controller (runActionWithRouteDocumentation @application routeDocumentation)
+        , routeInspection = RouteLeaf routeDocumentation
+        }
+{-# INLINEABLE buildDocumentedRoute #-}
 
-parseRoute :: forall controller application.
+parseRoute ::
+    forall controller application.
     ( ?request :: Request
     , ?respond :: Respond
     , CanRoute controller
@@ -1230,75 +1351,86 @@ parseRoute :: forall controller application.
     , ?application :: application
     , Typeable application
     , Typeable controller
-    ) => ControllerRoute application
+    ) =>
+    ControllerRoute application
 parseRoute = toControllerRoute @controller @application
-{-# INLINABLE parseRoute #-}
+{-# INLINEABLE parseRoute #-}
 
--- | Build a HashMap from full paths (prefix + action name) to Application closures.
--- The Application closures take the application value explicitly and handle query string
--- parsing, method validation, and controller execution.
--- Computed once per (controller, application) type pair (NOINLINE CAF).
-buildAutoRouteMap :: forall controller application.
+{- | Build a HashMap from full paths (prefix + action name) to Application closures.
+The Application closures take the application value explicitly and handle query string
+parsing, method validation, and controller execution.
+Computed once per (controller, application) type pair (NOINLINE CAF).
+-}
+buildAutoRouteMap ::
+    forall controller application.
     ( AutoRoute controller
     , Controller controller
     , InitControllerContext application
     , Typeable application
     , Typeable controller
-    ) => HashMap.HashMap ByteString (application -> Application)
-buildAutoRouteMap = HashMap.fromList
-    [ (prefix <> actionPath, handler)
-    | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-    , let actionName = ByteString.pack (showConstr constr)
-          actionPath = stripActionSuffixByteString actionName
-          allowedMethods = allowedMethodsForAction @controller actionName
-          handler app waiRequest waiRespond =
-              let ?application = app
-              in wrapRouterException do
-                  case parseMethod (requestMethod waiRequest) of
-                      Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
-                      Right method -> do
-                          unless (allowedMethods |> includes method)
-                              (Exception.throw UnexpectedMethodException { allowedMethods, method })
-                          case applyAction @controller constr (queryString waiRequest) of
-                              Left e -> Exception.throw e
-                              Right action -> runAction' @application action waiRequest waiRespond
-    ]
-    where
-        prefix :: ByteString
-        prefix = Text.encodeUtf8 (actionPrefixText @controller)
+    ) =>
+    HashMap.HashMap ByteString (application -> Application)
+buildAutoRouteMap =
+    HashMap.fromList
+        [ (prefix <> actionPath, handler)
+        | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+        , let actionName = ByteString.pack (showConstr constr)
+              actionPath = stripActionSuffixByteString actionName
+              allowedMethods = allowedMethodsForAction @controller actionName
+              handler app waiRequest waiRespond =
+                let ?application = app
+                 in wrapRouterException do
+                        case parseMethod (requestMethod waiRequest) of
+                            Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
+                            Right method -> do
+                                unless
+                                    (allowedMethods |> includes method)
+                                    (Exception.throw UnexpectedMethodException{allowedMethods, method})
+                                case applyAction @controller constr (queryString waiRequest) of
+                                    Left e -> Exception.throw e
+                                    Right action -> runAction' @application action waiRequest waiRespond
+        ]
+  where
+    prefix :: ByteString
+    prefix = Text.encodeUtf8 (actionPrefixText @controller)
 {-# NOINLINE buildAutoRouteMap #-}
 
-buildAutoRouteMapWithDocumentation :: forall controller application.
+buildAutoRouteMapWithDocumentation ::
+    forall controller application.
     ( AutoRoute controller
     , Controller controller
     , Data controller
     , InitControllerContext application
     , Typeable application
     , Typeable controller
-    ) => RouteDocumentation -> HashMap.HashMap ByteString (application -> Application)
-buildAutoRouteMapWithDocumentation routeDocumentation = HashMap.fromList
-    [ (prefix <> actionPath, handler)
-    | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
-    , let actionName = ByteString.pack (showConstr constr)
-          actionPath = stripActionSuffixByteString actionName
-          allowedMethods = allowedMethodsForAction @controller actionName
-          handler app waiRequest waiRespond =
-              let ?application = app
-              in case parseMethod (requestMethod waiRequest) of
-                  Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
-                  Right method -> do
-                      unless (allowedMethods |> includes method)
-                          (Exception.throw UnexpectedMethodException { allowedMethods, method })
-                      case applyAction @controller constr (queryString waiRequest) of
-                          Left e -> waiRespond $ responseLBS status400 [(hContentType, "text/plain")] (cs $ show e)
-                          Right action -> runActionWithRouteDocumentation @application routeDocumentation action waiRequest waiRespond
-    ]
-    where
-        prefix :: ByteString
-        prefix = Text.encodeUtf8 (actionPrefixText @controller)
+    ) =>
+    RouteDocumentation -> HashMap.HashMap ByteString (application -> Application)
+buildAutoRouteMapWithDocumentation routeDocumentation =
+    HashMap.fromList
+        [ (prefix <> actionPath, handler)
+        | constr <- dataTypeConstrs (dataTypeOf (Prelude.undefined :: controller))
+        , let actionName = ByteString.pack (showConstr constr)
+              actionPath = stripActionSuffixByteString actionName
+              allowedMethods = allowedMethodsForAction @controller actionName
+              handler app waiRequest waiRespond =
+                let ?application = app
+                 in case parseMethod (requestMethod waiRequest) of
+                        Left err -> error ("Invalid HTTP method: " <> ByteString.unpack err)
+                        Right method -> do
+                            unless
+                                (allowedMethods |> includes method)
+                                (Exception.throw UnexpectedMethodException{allowedMethods, method})
+                            case applyAction @controller constr (queryString waiRequest) of
+                                Left e -> waiRespond $ responseLBS status400 [(hContentType, "text/plain")] (cs $ show e)
+                                Right action -> runActionWithRouteDocumentation @application routeDocumentation action waiRequest waiRespond
+        ]
+  where
+    prefix :: ByteString
+    prefix = Text.encodeUtf8 (actionPrefixText @controller)
 {-# NOINLINE buildAutoRouteMapWithDocumentation #-}
 
-documentRoute :: forall controller application.
+documentRoute ::
+    forall controller application.
     ( ?request :: Request
     , ?respond :: Respond
     , Controller controller
@@ -1309,34 +1441,38 @@ documentRoute :: forall controller application.
     , ?application :: application
     , Typeable application
     , Typeable controller
-    ) => ControllerRoute application
+    ) =>
+    ControllerRoute application
 documentRoute =
     buildDocumentedRoute @controller @application
-        (DocumentedRoute
-            (AutoRouteControllerInfo
+        ( DocumentedRoute
+            ( AutoRouteControllerInfo
                 { documentedActions = Just (openApiActions @controller)
-                }))
-{-# INLINABLE documentRoute #-}
+                }
+            )
+        )
+{-# INLINEABLE documentRoute #-}
 
-parseUUIDOrTextId ::  ByteString -> Maybe Dynamic
-parseUUIDOrTextId queryVal = queryVal
-    |> fromASCIIBytes
-    |> \case
-        Just uuid -> uuid |> toDyn |> Just
-        Nothing -> Nothing
+parseUUIDOrTextId :: ByteString -> Maybe Dynamic
+parseUUIDOrTextId queryVal =
+    queryVal
+        |> fromASCIIBytes
+        |> \case
+            Just uuid -> uuid |> toDyn |> Just
+            Nothing -> Nothing
 
-parseRouteWithId
-    :: forall controller application.
-        (
-            ?request :: Request,
-            ?respond :: Respond,
-            CanRoute controller,
-            Controller controller,
-            InitControllerContext application,
-            ?application :: application,
-            Typeable application,
-            Typeable controller)
-        => ControllerRoute application
+parseRouteWithId ::
+    forall controller application.
+    ( ?request :: Request
+    , ?respond :: Respond
+    , CanRoute controller
+    , Controller controller
+    , InitControllerContext application
+    , ?application :: application
+    , Typeable application
+    , Typeable controller
+    ) =>
+    ControllerRoute application
 parseRouteWithId = parseRoute @controller @application
 
 catchAll :: forall action application. (Controller action, InitControllerContext application, Typeable action, ?application :: application, Typeable application, Data action) => action -> ControllerRoute application
@@ -1354,63 +1490,65 @@ instance {-# OVERLAPPABLE #-} (HasPath action) => ConvertibleStrings action Html
 -- | Parses and returns an UUID
 parseUUID :: Parser UUID
 parseUUID = do
-        uuid <- take 36
-        case fromASCIIBytes uuid of
-            Just theUUID -> pure theUUID
-            Nothing -> fail "not uuid"
-{-# INLINABLE parseUUID #-}
+    uuid <- take 36
+    case fromASCIIBytes uuid of
+        Just theUUID -> pure theUUID
+        Nothing -> fail "not uuid"
+{-# INLINEABLE parseUUID #-}
 
 -- | Parses an UUID, afterwards wraps it in an Id
 parseId :: ((ModelSupport.PrimaryKey table) ~ UUID) => Parser (ModelSupport.Id' table)
 parseId = ModelSupport.Id <$> parseUUID
-{-# INLINABLE parseId #-}
+{-# INLINEABLE parseId #-}
 
 -- | Returns all the remaining text until the end of the input
 remainingText :: Parser Text
 remainingText = Text.decodeUtf8 <$> takeByteString
-{-# INLINABLE remainingText #-}
+{-# INLINEABLE remainingText #-}
 
 -- | Parses until the next @/@
 parseText :: Parser Text
 parseText = Text.decodeUtf8 <$> takeTill ('/' ==)
-{-# INLINABLE parseText #-}
+{-# INLINEABLE parseText #-}
 
 parseIntegerId :: (Data idType) => ByteString -> Maybe idType
-parseIntegerId queryVal = let
-    rawValue :: Maybe Integer = readMaybe (cs queryVal :: String)
-    in
-       rawValue >>= Just . unsafeCoerce
+parseIntegerId queryVal =
+    let
+        rawValue :: Maybe Integer = readMaybe (cs queryVal :: String)
+     in
+        rawValue >>= Just . unsafeCoerce
 
--- | Parses and returns an integer
--- parseRational :: (Integral a) => Parser a
--- parseRational = Attoparsec.decimal
+{- | Parses and returns an integer
+parseRational :: (Integral a) => Parser a
+parseRational = Attoparsec.decimal
+-}
 
--- | Parses a route query parameter
---
--- __Example:__
---
--- > let showPost = do
--- >     string "/post"
--- >     let postId = routeParam "postId"
--- >     pure ShowPostAction { .. }
--- Will parse the `postId` query in `/post?postId=09b545dd-9744-4ef8-87b8-8d227f4faa1e`
---
+{- | Parses a route query parameter
+
+__Example:__
+
+> let showPost = do
+>     string "/post"
+>     let postId = routeParam "postId"
+>     pure ShowPostAction { .. }
+Will parse the `postId` query in `/post?postId=09b545dd-9744-4ef8-87b8-8d227f4faa1e`
+-}
 routeParam :: (?request :: Request, ?respond :: Respond, ParamReader paramType) => ByteString -> paramType
 routeParam paramName =
     let customFields = TypeMap.insert ?request TypeMap.empty
-    in
-        let ?context = FrozenControllerContext { customFields }
-        in param paramName
+     in let ?context = FrozenControllerContext{customFields}
+         in param paramName
 
--- | Display a better error when the user missed to pass an argument to an action.
---
--- E.g. when you forgot to pass a projectId to the ShowProjectAction:
---
--- > <a href={ShowProjectAction}>Show project</a>
---
--- The correct code would be this:
---
--- > <a href={ShowProjectAction projectId}>Show project</a>
---
--- See https://github.com/digitallyinduced/ihp/issues/840
-instance ((T.TypeError (T.Text "Looks like you forgot to pass a " :<>: (T.ShowType argument) :<>: T.Text " to this " :<>: (T.ShowType controller))), Data argument, Data controller, Data (argument -> controller)) => AutoRoute (argument -> controller) where
+{- | Display a better error when the user missed to pass an argument to an action.
+
+E.g. when you forgot to pass a projectId to the ShowProjectAction:
+
+> <a href={ShowProjectAction}>Show project</a>
+
+The correct code would be this:
+
+> <a href={ShowProjectAction projectId}>Show project</a>
+
+See https://github.com/digitallyinduced/ihp/issues/840
+-}
+instance ((T.TypeError (T.Text "Looks like you forgot to pass a " :<>: (T.ShowType argument) :<>: T.Text " to this " :<>: (T.ShowType controller))), Data argument, Data controller, Data (argument -> controller)) => AutoRoute (argument -> controller)

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -22,6 +21,7 @@ module IHP.RouterSupport (
     HasOpenApiRequestBody (..),
     actionDoc,
     actionDocFor,
+    actionDocForRequestBody,
     setOpenApiSummary,
     setOpenApiDescription,
     setOpenApiTags,
@@ -71,7 +71,6 @@ import Control.Exception.Safe (SomeException, catch, throwIO)
 import Control.Monad (join, unless)
 import Control.Monad.State.Strict qualified as State
 import Data.Aeson qualified as JSON
-import Data.Aeson qualified as Aeson
 import Data.Attoparsec.ByteString.Char8 (Parser, choice, endOfInput, parseOnly, string, take, takeByteString, takeTill)
 import Data.Attoparsec.ByteString.Char8 qualified as Attoparsec
 import Data.ByteString (ByteString)
@@ -186,23 +185,6 @@ class (JSON.FromJSON (OpenApiRequestBody controller actionName), ToSchema (OpenA
     openApiRequestBodyRequired :: Bool
     openApiRequestBodyRequired = True
 
-class ActionDocRequestBodyProvider controller (actionName :: Symbol) where
-    actionDocRequestBodyFor :: Maybe OpenApiRequestBodyDoc
-
-instance {-# OVERLAPPABLE #-} ActionDocRequestBodyProvider controller actionName where
-    actionDocRequestBodyFor = Nothing
-
-instance
-    (HasOpenApiRequestBody controller actionName) =>
-    ActionDocRequestBodyProvider controller actionName
-    where
-    actionDocRequestBodyFor =
-        Just
-            OpenApiRequestBodyDoc
-                { requestBodyRequired = openApiRequestBodyRequired @controller @actionName
-                , requestBodySchema = Proxy @(OpenApiRequestBody controller actionName)
-                }
-
 actionDoc ::
     forall view controller.
     ( ViewSupport.View view
@@ -227,7 +209,6 @@ actionDoc actionName =
 actionDocFor ::
     forall actionName view controller.
     ( KnownSymbol actionName
-    , ActionDocRequestBodyProvider controller actionName
     , ViewSupport.View view
     , Typeable.Typeable view
     , JSON.ToJSON (ViewSupport.JsonResponse view)
@@ -243,9 +224,24 @@ actionDocFor =
         , actionDocOperationId = Nothing
         , actionDocView = Proxy @view
         , actionDocTypedJson = JSON.toJSON . ViewSupport.jsonTyped
-        , actionDocRequestBody = actionDocRequestBodyFor @controller @actionName
+        , actionDocRequestBody = Nothing
         }
 {-# INLINE actionDocFor #-}
+
+actionDocForRequestBody ::
+    forall actionName view controller.
+    ( KnownSymbol actionName
+    , HasOpenApiRequestBody controller actionName
+    , ViewSupport.View view
+    , Typeable.Typeable view
+    , JSON.ToJSON (ViewSupport.JsonResponse view)
+    , ToSchema (ViewSupport.JsonResponse view)
+    ) =>
+    ActionDoc controller
+actionDocForRequestBody =
+    actionDocFor @actionName @view @controller
+        |> setOpenApiRequestBody @(OpenApiRequestBody controller actionName)
+{-# INLINE actionDocForRequestBody #-}
 
 setOpenApiSummary :: Text -> ActionDoc controller -> ActionDoc controller
 setOpenApiSummary summary ActionDoc{actionDocName, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson, actionDocRequestBody} =
@@ -329,7 +325,7 @@ decodeActionRequestBody ::
     ) =>
     IO (Either String (OpenApiRequestBody controller actionName))
 decodeActionRequestBody =
-    Aeson.eitherDecode <$> getRequestBody
+    JSON.eitherDecode <$> getRequestBody
 {-# INLINE decodeActionRequestBody #-}
 
 class (AutoRoute controller) => OpenApiController controller where

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -178,7 +178,7 @@ data OpenApiRequestBodyDoc where
         ) =>
         { requestBodyRequired :: Bool
         , requestBodySchema :: Proxy body
-        , requestBodyTypeRep :: Typeable.TypeRep body
+        , requestBodyTypeRep :: Typeable.TypeRep
         } ->
         OpenApiRequestBodyDoc
 

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -173,9 +173,12 @@ data ActionDoc controller where
 data OpenApiRequestBodyDoc where
     OpenApiRequestBodyDoc ::
         forall body.
-        (ToSchema body) =>
+        ( ToSchema body
+        , Typeable.Typeable body
+        ) =>
         { requestBodyRequired :: Bool
         , requestBodySchema :: Proxy body
+        , requestBodyTypeRep :: Typeable.TypeRep body
         } ->
         OpenApiRequestBodyDoc
 
@@ -251,6 +254,7 @@ actionDocForRequestBody =
                 OpenApiRequestBodyDoc
                     { requestBodyRequired = openApiRequestBodyRequired @controller @actionName
                     , requestBodySchema = Proxy @(OpenApiRequestBody controller actionName)
+                    , requestBodyTypeRep = Typeable.typeRep (Proxy @(OpenApiRequestBody controller actionName))
                     }
         }
 {-# INLINE actionDocForRequestBody #-}
@@ -312,18 +316,27 @@ setOpenApiOperationId operationId ActionDoc{actionDocName, actionDocSummary, act
 {-# INLINE setOpenApiOperationId #-}
 
 decodeActionRequestBody ::
-    forall actionName controller.
-    ( HasOpenApiRequestBody controller actionName
+    forall body controller.
+    ( OpenApiController controller
+    , JSON.FromJSON body
+    , Typeable.Typeable body
     , Data controller
     , ?request :: Request
     , ?theAction :: controller
     ) =>
-    IO (Either String (OpenApiRequestBody controller actionName))
+    IO (Either String body)
 decodeActionRequestBody = do
-    let expectedActionName = symbolVal (Proxy @actionName)
-    let actualActionName = showConstr (toConstr ?theAction)
-    unless (actualActionName == expectedActionName) do
-        fail ("decodeActionRequestBody expected action " <> expectedActionName <> " but current action is " <> actualActionName)
+    let currentActionName = cs (showConstr (toConstr ?theAction))
+    let maybeRequestBodyDoc =
+            openApiActions @controller
+                |> find (\ActionDoc{actionDocName} -> actionDocName == currentActionName)
+                >>= (.actionDocRequestBody)
+    case maybeRequestBodyDoc of
+        Nothing ->
+            fail ("decodeActionRequestBody found no registered request body for action " <> cs currentActionName)
+        Just OpenApiRequestBodyDoc{requestBodyTypeRep} ->
+            unless (requestBodyTypeRep == Typeable.typeRep (Proxy @body)) do
+                fail ("decodeActionRequestBody expected " <> show requestBodyTypeRep <> " for action " <> cs currentActionName <> " but handler requested " <> show (Typeable.typeRep (Proxy @body)))
     JSON.eitherDecode <$> getRequestBody
 {-# INLINE decodeActionRequestBody #-}
 

--- a/ihp/IHP/RouterSupport.hs
+++ b/ihp/IHP/RouterSupport.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module IHP.RouterSupport (
@@ -15,12 +19,15 @@ module IHP.RouterSupport (
     documentRoute,
     ActionDoc (..),
     OpenApiRequestBodyDoc (..),
+    HasOpenApiRequestBody (..),
     actionDoc,
+    actionDocFor,
     setOpenApiSummary,
     setOpenApiDescription,
     setOpenApiTags,
     setOpenApiOperationId,
     setOpenApiRequestBody,
+    decodeActionRequestBody,
     runAction,
     get,
     post,
@@ -64,6 +71,7 @@ import Control.Exception.Safe (SomeException, catch, throwIO)
 import Control.Monad (join, unless)
 import Control.Monad.State.Strict qualified as State
 import Data.Aeson qualified as JSON
+import Data.Aeson qualified as Aeson
 import Data.Attoparsec.ByteString.Char8 (Parser, choice, endOfInput, parseOnly, string, take, takeByteString, takeTill)
 import Data.Attoparsec.ByteString.Char8 qualified as Attoparsec
 import Data.ByteString (ByteString)
@@ -173,6 +181,28 @@ data OpenApiRequestBodyDoc where
         } ->
         OpenApiRequestBodyDoc
 
+class (JSON.FromJSON (OpenApiRequestBody controller actionName), ToSchema (OpenApiRequestBody controller actionName)) => HasOpenApiRequestBody controller (actionName :: Symbol) where
+    type OpenApiRequestBody controller actionName :: Type
+    openApiRequestBodyRequired :: Bool
+    openApiRequestBodyRequired = True
+
+class ActionDocRequestBodyProvider controller (actionName :: Symbol) where
+    actionDocRequestBodyFor :: Maybe OpenApiRequestBodyDoc
+
+instance {-# OVERLAPPABLE #-} ActionDocRequestBodyProvider controller actionName where
+    actionDocRequestBodyFor = Nothing
+
+instance
+    (HasOpenApiRequestBody controller actionName) =>
+    ActionDocRequestBodyProvider controller actionName
+    where
+    actionDocRequestBodyFor =
+        Just
+            OpenApiRequestBodyDoc
+                { requestBodyRequired = openApiRequestBodyRequired @controller @actionName
+                , requestBodySchema = Proxy @(OpenApiRequestBody controller actionName)
+                }
+
 actionDoc ::
     forall view controller.
     ( ViewSupport.View view
@@ -193,6 +223,29 @@ actionDoc actionName =
         , actionDocRequestBody = Nothing
         }
 {-# INLINE actionDoc #-}
+
+actionDocFor ::
+    forall actionName view controller.
+    ( KnownSymbol actionName
+    , ActionDocRequestBodyProvider controller actionName
+    , ViewSupport.View view
+    , Typeable.Typeable view
+    , JSON.ToJSON (ViewSupport.JsonResponse view)
+    , ToSchema (ViewSupport.JsonResponse view)
+    ) =>
+    ActionDoc controller
+actionDocFor =
+    ActionDoc
+        { actionDocName = cs (symbolVal (Proxy @actionName))
+        , actionDocSummary = Nothing
+        , actionDocDescription = Nothing
+        , actionDocTags = []
+        , actionDocOperationId = Nothing
+        , actionDocView = Proxy @view
+        , actionDocTypedJson = JSON.toJSON . ViewSupport.jsonTyped
+        , actionDocRequestBody = actionDocRequestBodyFor @controller @actionName
+        }
+{-# INLINE actionDocFor #-}
 
 setOpenApiSummary :: Text -> ActionDoc controller -> ActionDoc controller
 setOpenApiSummary summary ActionDoc{actionDocName, actionDocDescription, actionDocTags, actionDocOperationId, actionDocView, actionDocTypedJson, actionDocRequestBody} =
@@ -268,6 +321,16 @@ setOpenApiRequestBody ActionDoc{actionDocName, actionDocSummary, actionDocDescri
                     }
         }
 {-# INLINE setOpenApiRequestBody #-}
+
+decodeActionRequestBody ::
+    forall controller actionName.
+    ( HasOpenApiRequestBody controller actionName
+    , ?request :: Request
+    ) =>
+    IO (Either String (OpenApiRequestBody controller actionName))
+decodeActionRequestBody =
+    Aeson.eitherDecode <$> getRequestBody
+{-# INLINE decodeActionRequestBody #-}
 
 class (AutoRoute controller) => OpenApiController controller where
     openApiActions :: [ActionDoc controller]

--- a/ihp/Test/Test/OpenApiSupportSpec.hs
+++ b/ihp/Test/Test/OpenApiSupportSpec.hs
@@ -212,7 +212,7 @@ instance HasOpenApiRequestBody CrudNamedApiController "CreateApiSessionAction" w
 
 instance OpenApiController CrudNamedApiController where
     openApiActions =
-        [ actionDocFor @"CreateApiSessionAction" @AckView
+        [ actionDocForRequestBody @"CreateApiSessionAction" @AckView
         , actionDocFor @"ShowApiSessionAction" @AckView
         ]
 

--- a/ihp/Test/Test/OpenApiSupportSpec.hs
+++ b/ihp/Test/Test/OpenApiSupportSpec.hs
@@ -165,7 +165,7 @@ instance Controller DocumentedCustomPathController where
 
 instance Controller CrudNamedApiController where
     action CreateApiSessionAction = do
-        requestBodyResult <- decodeActionRequestBody @"CreateApiSessionAction"
+        requestBodyResult <- decodeActionRequestBody @CreateSessionRequest
         case requestBodyResult of
             Left _ -> renderPlain "Invalid JSON"
             Right (_ :: CreateSessionRequest) -> render AckView

--- a/ihp/Test/Test/OpenApiSupportSpec.hs
+++ b/ihp/Test/Test/OpenApiSupportSpec.hs
@@ -165,7 +165,7 @@ instance Controller DocumentedCustomPathController where
 
 instance Controller CrudNamedApiController where
     action CreateApiSessionAction = do
-        requestBodyResult <- decodeActionRequestBody @CrudNamedApiController @"CreateApiSessionAction"
+        requestBodyResult <- decodeActionRequestBody @"CreateApiSessionAction"
         case requestBodyResult of
             Left _ -> renderPlain "Invalid JSON"
             Right (_ :: CreateSessionRequest) -> render AckView

--- a/ihp/Test/Test/OpenApiSupportSpec.hs
+++ b/ihp/Test/Test/OpenApiSupportSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Test.OpenApiSupportSpec where
@@ -90,6 +91,7 @@ data CreateSessionRequest = CreateSessionRequest
     deriving (Eq, Show, Generic)
 
 instance JSON.ToJSON CreateSessionRequest
+instance JSON.FromJSON CreateSessionRequest
 instance ToSchema CreateSessionRequest
 
 instance View BandView where
@@ -162,7 +164,11 @@ instance Controller DocumentedCustomPathController where
     action ShowDocumentedCustomPathAction{..} = render DocumentedCustomPathView{..}
 
 instance Controller CrudNamedApiController where
-    action CreateApiSessionAction = render AckView
+    action CreateApiSessionAction = do
+        requestBodyResult <- decodeActionRequestBody @CrudNamedApiController @"CreateApiSessionAction"
+        case requestBodyResult of
+            Left _ -> renderPlain "Invalid JSON"
+            Right (_ :: CreateSessionRequest) -> render AckView
     action ShowApiSessionAction = render AckView
 
 instance AutoRoute DocumentedController where
@@ -201,11 +207,13 @@ instance OpenApiController DocumentedCustomPathController where
 
 instance AutoRoute CrudNamedApiController
 
+instance HasOpenApiRequestBody CrudNamedApiController "CreateApiSessionAction" where
+    type OpenApiRequestBody CrudNamedApiController "CreateApiSessionAction" = CreateSessionRequest
+
 instance OpenApiController CrudNamedApiController where
     openApiActions =
-        [ actionDoc @AckView "CreateApiSessionAction"
-            |> setOpenApiRequestBody @CreateSessionRequest
-        , actionDoc @AckView "ShowApiSessionAction"
+        [ actionDocFor @"CreateApiSessionAction" @AckView
+        , actionDocFor @"ShowApiSessionAction" @AckView
         ]
 
 instance FrontController WebApplication where

--- a/ihp/Test/Test/OpenApiSupportSpec.hs
+++ b/ihp/Test/Test/OpenApiSupportSpec.hs
@@ -11,7 +11,6 @@ import Data.Attoparsec.ByteString.Char8 (endOfInput, string)
 import Data.Text qualified as Text
 import IHP.ControllerPrelude hiding (find, get, request)
 import IHP.Environment
-import IHP.FrameworkConfig
 import IHP.Test.Mocking
 import IHP.ViewPrelude
 import Network.HTTP.Types

--- a/ihp/Test/Test/OpenApiSupportSpec.hs
+++ b/ihp/Test/Test/OpenApiSupportSpec.hs
@@ -12,8 +12,6 @@ import Data.Text qualified as Text
 import IHP.ControllerPrelude hiding (find, get, request)
 import IHP.Environment
 import IHP.FrameworkConfig
-import IHP.Prelude
-import IHP.RouterSupport hiding (get)
 import IHP.Test.Mocking
 import IHP.ViewPrelude
 import Network.HTTP.Types

--- a/ihp/Test/Test/OpenApiSupportSpec.hs
+++ b/ihp/Test/Test/OpenApiSupportSpec.hs
@@ -4,31 +4,31 @@
 module Test.OpenApiSupportSpec where
 
 import ClassyPrelude
-import qualified Prelude
-import Test.Hspec
-import IHP.Test.Mocking
-import IHP.Prelude
+import Data.Aeson qualified as JSON
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Attoparsec.ByteString.Char8 (endOfInput, string)
+import Data.Text qualified as Text
+import IHP.ControllerPrelude hiding (find, get, request)
 import IHP.Environment
 import IHP.FrameworkConfig
+import IHP.Prelude
 import IHP.RouterSupport hiding (get)
+import IHP.Test.Mocking
 import IHP.ViewPrelude
-import IHP.ControllerPrelude hiding (get, request, find)
-import Network.Wai.Test
 import Network.HTTP.Types
-import Data.Attoparsec.ByteString.Char8 (string, endOfInput)
-import qualified Data.Aeson as JSON
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Text as Text
+import Network.Wai.Test
+import Test.Hspec
+import Prelude qualified
 
-data Band' = Band { id :: Id' "open_api_bands", meta :: MetaBag } deriving (Eq, Show)
+data Band' = Band {id :: Id' "open_api_bands", meta :: MetaBag} deriving (Eq, Show)
 type Band = Band'
 type instance GetTableName Band' = "open_api_bands"
 type instance GetModelByTableName "open_api_bands" = Band
 type instance GetModelName Band' = "Band"
 type instance PrimaryKey "open_api_bands" = Integer
 
-data Performance' = Performance { id :: Id' "open_api_performances", meta :: MetaBag } deriving (Eq, Show)
+data Performance' = Performance {id :: Id' "open_api_performances", meta :: MetaBag} deriving (Eq, Show)
 type Performance = Performance'
 type instance GetTableName Performance' = "open_api_performances"
 type instance GetModelByTableName "open_api_performances" = Performance
@@ -38,19 +38,19 @@ type instance PrimaryKey "open_api_performances" = UUID
 data WebApplication = WebApplication deriving (Eq, Show, Data)
 
 data DocumentedController
-    = ShowBandAction { bandId :: !(Id Band), page :: !(Maybe Int), tags :: ![Text] }
+    = ShowBandAction {bandId :: !(Id Band), page :: !(Maybe Int), tags :: ![Text]}
     | LegacyJsonAction
     | WrongJsonAction
-    | WrongJsonShapeAction { bandId :: !(Id Band) }
+    | WrongJsonShapeAction {bandId :: !(Id Band)}
     deriving (Eq, Show, Data)
 
 data CustomRouteController
     = ListCustomAction
-    | ShowCustomAction { performanceId :: !(Id Performance) }
+    | ShowCustomAction {performanceId :: !(Id Performance)}
     deriving (Eq, Show, Data)
 
 data DocumentedCustomPathController
-    = ShowDocumentedCustomPathAction { bandId :: !(Id Band) }
+    = ShowDocumentedCustomPathAction {bandId :: !(Id Band)}
     deriving (Eq, Show, Data)
 
 data CrudNamedApiController
@@ -75,8 +75,8 @@ instance JSON.ToJSON BandPayload
 instance ToSchema BandPayload
 
 data LegacyJsonView = LegacyJsonView
-data WrongJsonShapeView = WrongJsonShapeView { bandId :: !(Id Band) }
-data DocumentedCustomPathView = DocumentedCustomPathView { bandId :: !(Id Band) }
+data WrongJsonShapeView = WrongJsonShapeView {bandId :: !(Id Band)}
+data DocumentedCustomPathView = DocumentedCustomPathView {bandId :: !(Id Band)}
 data AckView = AckView
 
 data AckPayload = AckPayload
@@ -87,69 +87,82 @@ data AckPayload = AckPayload
 instance JSON.ToJSON AckPayload
 instance ToSchema AckPayload
 
+data CreateSessionRequest = CreateSessionRequest
+    { token :: !Text
+    }
+    deriving (Eq, Show, Generic)
+
+instance JSON.ToJSON CreateSessionRequest
+instance ToSchema CreateSessionRequest
+
 instance View BandView where
-    html BandView { .. } = [hsx||]
+    html BandView{..} = [hsx||]
 
     type JsonResponse BandView = BandPayload
 
-    jsonTyped BandView { .. } = BandPayload
-        { bandId = unpackId bandId
-        , page
-        , tags
-        }
+    jsonTyped BandView{..} =
+        BandPayload
+            { bandId = unpackId bandId
+            , page
+            , tags
+            }
 
 instance View LegacyJsonView where
     html LegacyJsonView = [hsx||]
 
-    json LegacyJsonView = JSON.object
-        [ "legacy" JSON..= True
-        ]
+    json LegacyJsonView =
+        JSON.object
+            [ "legacy" JSON..= True
+            ]
 
 instance View WrongJsonShapeView where
-    html WrongJsonShapeView { .. } = [hsx||]
+    html WrongJsonShapeView{..} = [hsx||]
 
     type JsonResponse WrongJsonShapeView = BandPayload
 
-    jsonTyped WrongJsonShapeView { .. } = BandPayload
-        { bandId = unpackId bandId
-        , page = Nothing
-        , tags = []
-        }
+    jsonTyped WrongJsonShapeView{..} =
+        BandPayload
+            { bandId = unpackId bandId
+            , page = Nothing
+            , tags = []
+            }
 
-    json WrongJsonShapeView { .. } = JSON.object
-        [ "legacyBandId" JSON..= unpackId bandId
-        ]
+    json WrongJsonShapeView{..} =
+        JSON.object
+            [ "legacyBandId" JSON..= unpackId bandId
+            ]
 
 instance View DocumentedCustomPathView where
-    html DocumentedCustomPathView { .. } = [hsx||]
+    html DocumentedCustomPathView{..} = [hsx||]
 
     type JsonResponse DocumentedCustomPathView = BandPayload
 
-    jsonTyped DocumentedCustomPathView { .. } = BandPayload
-        { bandId = unpackId bandId
-        , page = Nothing
-        , tags = []
-        }
+    jsonTyped DocumentedCustomPathView{..} =
+        BandPayload
+            { bandId = unpackId bandId
+            , page = Nothing
+            , tags = []
+            }
 
 instance View AckView where
     html AckView = [hsx||]
 
     type JsonResponse AckView = AckPayload
 
-    jsonTyped AckView = AckPayload { ok = True }
+    jsonTyped AckView = AckPayload{ok = True}
 
 instance Controller DocumentedController where
-    action ShowBandAction { .. } = render BandView { .. }
+    action ShowBandAction{..} = render BandView{..}
     action LegacyJsonAction = render LegacyJsonView
     action WrongJsonAction = render LegacyJsonView
-    action WrongJsonShapeAction { .. } = render WrongJsonShapeView { .. }
+    action WrongJsonShapeAction{..} = render WrongJsonShapeView{..}
 
 instance Controller CustomRouteController where
     action ListCustomAction = renderPlain "ListCustomAction"
-    action ShowCustomAction { .. } = renderPlain (cs (Prelude.show performanceId))
+    action ShowCustomAction{..} = renderPlain (cs (Prelude.show performanceId))
 
 instance Controller DocumentedCustomPathController where
-    action ShowDocumentedCustomPathAction { .. } = render DocumentedCustomPathView { .. }
+    action ShowDocumentedCustomPathAction{..} = render DocumentedCustomPathView{..}
 
 instance Controller CrudNamedApiController where
     action CreateApiSessionAction = render AckView
@@ -173,16 +186,16 @@ instance AutoRoute CustomRouteController where
         performanceId <- parseId
         endOfInput
         onlyAllowMethods [GET, HEAD]
-        pure ShowCustomAction { performanceId }
+        pure ShowCustomAction{performanceId}
 
-    customPathTo ShowCustomAction { performanceId } = Just ("/custom/" <> cs (Prelude.show performanceId))
+    customPathTo ShowCustomAction{performanceId} = Just ("/custom/" <> cs (Prelude.show performanceId))
     customPathTo _ = Nothing
 
 instance AutoRoute DocumentedCustomPathController where
     autoRoute = autoRouteWithIdType (parseIntegerId @(Id Band))
     applyAction = applyConstr (parseIntegerId @(Id Band))
 
-    customPathTo ShowDocumentedCustomPathAction { bandId } = Just ("/bands/" <> cs (Prelude.show (unpackId bandId)))
+    customPathTo ShowDocumentedCustomPathAction{bandId} = Just ("/bands/" <> cs (Prelude.show (unpackId bandId)))
 
 instance OpenApiController DocumentedCustomPathController where
     openApiActions =
@@ -194,6 +207,7 @@ instance AutoRoute CrudNamedApiController
 instance OpenApiController CrudNamedApiController where
     openApiActions =
         [ actionDoc @AckView "CreateApiSessionAction"
+            |> setOpenApiRequestBody @CreateSessionRequest
         , actionDoc @AckView "ShowApiSessionAction"
         ]
 
@@ -203,11 +217,11 @@ instance FrontController WebApplication where
         , documentRoute @DocumentedCustomPathController
         , documentRoute @CrudNamedApiController
         , parseRoute @CustomRouteController
-        , swaggerUiWithOptions ((defaultSwaggerUiOptions @WebApplication) { swaggerUiPath = "/docs", swaggerUiTitle = Just "Band API Docs" })
+        , swaggerUiWithOptions ((defaultSwaggerUiOptions @WebApplication){swaggerUiPath = "/docs", swaggerUiTitle = Just "Band API Docs"})
         ]
 
 instance FrontController RootApplication where
-    controllers = [ mountFrontController WebApplication ]
+    controllers = [mountFrontController WebApplication]
 
 defaultLayout :: Html -> Html
 defaultLayout inner = [hsx|{inner}|]
@@ -218,13 +232,17 @@ instance InitControllerContext WebApplication where
 instance InitControllerContext RootApplication
 
 testJson :: ByteString -> Session SResponse
-testJson url = request $ setPath defaultRequest
-    { requestMethod = methodGet
-    , requestHeaders = [(hAccept, "application/json")]
-    } url
+testJson url =
+    request $
+        setPath
+            defaultRequest
+                { requestMethod = methodGet
+                , requestHeaders = [(hAccept, "application/json")]
+                }
+            url
 
 testGet :: ByteString -> Session SResponse
-testGet url = request $ setPath defaultRequest { requestMethod = methodGet } url
+testGet url = request $ setPath defaultRequest{requestMethod = methodGet} url
 
 assertJsonBody :: JSON.Value -> SResponse -> IO ()
 assertJsonBody expected response = do
@@ -257,11 +275,12 @@ tests :: Spec
 tests = aroundAll (withMockContextAndApp RootApplication config) do
     describe "JSON rendering" do
         it "renders typed jsonTyped values through render" $ withContextAndApp \application -> do
-            let expected = JSON.object
-                    [ "bandId" JSON..= (12 :: Integer)
-                    , "page" JSON..= Just (2 :: Int)
-                    , "tags" JSON..= (["rock", "jazz"] :: [Text])
-                    ]
+            let expected =
+                    JSON.object
+                        [ "bandId" JSON..= (12 :: Integer)
+                        , "page" JSON..= Just (2 :: Int)
+                        , "tags" JSON..= (["rock", "jazz"] :: [Text])
+                        ]
             runSession (testJson "test/ShowBand?bandId=12&page=2&tags=rock,jazz") application >>= assertJsonBody expected
 
         it "keeps legacy json overrides working" $ withContextAndApp \application -> do
@@ -335,6 +354,23 @@ tests = aroundAll (withMockContextAndApp RootApplication config) do
             lookupPathOperation "/test/ShowApiSession" "head" spec `shouldSatisfy` isJust
             lookupPathOperation "/test/ApiSession" "post" spec `shouldBe` Nothing
             lookupPathOperation "/test/ApiSession" "get" spec `shouldBe` Nothing
+
+        it "includes request body schemas for documented JSON actions" $ withContextAndApp \_ -> do
+            let spec = buildOpenApi RootApplication
+
+            let Just operation = lookupPathOperation "/test/CreateApiSession" "post" spec
+            let Just requestBody =
+                    lookupValue "requestBody" operation
+                        >>= lookupValue "content"
+                        >>= lookupValue "application/json"
+                        >>= lookupValue "schema"
+
+            lookupValue "$ref" requestBody `shouldBe` Just (JSON.String "#/components/schemas/CreateSessionRequest")
+
+            let Just componentsSchemas = lookupValue "components" spec >>= lookupValue "schemas"
+            let Just createSessionRequestSchema = lookupValue "CreateSessionRequest" componentsSchemas
+            lookupValue "type" createSessionRequestSchema `shouldBe` Just (JSON.String "object")
+            (lookupValue "properties" createSessionRequestSchema >>= lookupValue "token") `shouldSatisfy` isJust
 
     describe "Swagger UI" do
         it "serves the generated OpenAPI JSON from the mounted router" $ withContextAndApp \application -> do


### PR DESCRIPTION
## Summary
- add request body support to documented OpenAPI actions
- emit requestBody schemas from IHP OpenApiSupport
- cover the feature in OpenApiSupportSpec

## Why
Gitoku needed typed request bodies in the generated OpenAPI client, and IHP previously only documented responses for actionDoc routes.
